### PR TITLE
[HIR] Add InferTypes pass and basic ops

### DIFF
--- a/include/silicon/Dialect/HIR/HIRDialect.td
+++ b/include/silicon/Dialect/HIR/HIRDialect.td
@@ -20,6 +20,8 @@ def HIRDialect : Dialect {
     The HIR dialect defines operations and types to represent a Silicon design
     during constant evaluation and type checking.
   }];
+
+  let useDefaultTypePrinterParser = 1;
 }
 
 #endif // SILICON_DIALECT_HIR_HIRDIALECT_TD

--- a/include/silicon/Dialect/HIR/HIROps.h
+++ b/include/silicon/Dialect/HIR/HIROps.h
@@ -1,0 +1,19 @@
+//===- HIROps.h - High-level IR dialect definition ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpImplementation.h"
+#include "silicon/Dialect/HIR/HIRTypes.h"
+
+// Pull in the generated dialect definition.
+#define GET_OP_CLASSES
+#include "silicon/Dialect/HIR/HIROps.h.inc"

--- a/include/silicon/Dialect/HIR/HIROps.td
+++ b/include/silicon/Dialect/HIR/HIROps.td
@@ -10,6 +10,33 @@
 #define SILICON_DIALECT_HIR_HIROPS_TD
 
 include "silicon/Dialect/HIR/HIRDialect.td"
+include "silicon/Dialect/HIR/HIRTypes.td"
 include "mlir/IR/OpBase.td"
+
+// Base class for the operations in this dialect.
+class HIROp<string mnemonic, list<Trait> traits = []> :
+  Op<HIRDialect, mnemonic, traits>;
+
+def InferrableTypeOp : HIROp<"inferrable_type", []> {
+  let results = (outs TypeType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def LetOp : HIROp<"let", []> {
+  let arguments = (ins StrAttr:$name, TypeType:$type);
+  let results = (outs TypeType:$result);
+  let assemblyFormat = "$name `:` $type attr-dict";
+}
+
+def UnifyTypeOp : HIROp<"unify_type", []> {
+  let arguments = (ins TypeType:$lhs, TypeType:$rhs);
+  let results = (outs TypeType:$result);
+  let assemblyFormat = "$lhs `,` $rhs attr-dict";
+}
+
+def StoreOp : HIROp<"store", []> {
+  let arguments = (ins TypeType:$target, TypeType:$value, TypeType:$valueType);
+  let assemblyFormat = "$target `,` $value `:` $valueType attr-dict";
+}
 
 #endif // SILICON_DIALECT_HIR_HIROPS_TD

--- a/include/silicon/Dialect/HIR/HIRPasses.h
+++ b/include/silicon/Dialect/HIR/HIRPasses.h
@@ -1,0 +1,27 @@
+//===- HIRPasses.h - High-level IR transformation passes ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+#include <optional>
+
+namespace mlir {
+class Pass;
+} // namespace mlir
+
+namespace silicon {
+namespace hir {
+
+#define GEN_PASS_DECL
+#define GEN_PASS_REGISTRATION
+#include "silicon/Dialect/HIR/HIRPasses.h.inc"
+
+} // namespace hir
+} // namespace silicon

--- a/include/silicon/Dialect/HIR/HIRPasses.td
+++ b/include/silicon/Dialect/HIR/HIRPasses.td
@@ -12,4 +12,7 @@
 include "silicon/Dialect/HIR/HIRDialect.td"
 include "mlir/Pass/PassBase.td"
 
+def InferTypesPass : Pass<"infer-types"> {
+}
+
 #endif // SILICON_DIALECT_HIR_HIRPASSES_TD

--- a/include/silicon/Dialect/HIR/HIRTypes.h
+++ b/include/silicon/Dialect/HIR/HIRTypes.h
@@ -1,0 +1,16 @@
+//===- HIRTypes.h - High-level IR types -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Types.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "silicon/Dialect/HIR/HIRTypes.h.inc"

--- a/include/silicon/Dialect/HIR/HIRTypes.td
+++ b/include/silicon/Dialect/HIR/HIRTypes.td
@@ -12,4 +12,14 @@
 include "silicon/Dialect/HIR/HIRDialect.td"
 include "mlir/IR/AttrTypeBase.td"
 
+class HIRTypeDef<string name, list<Trait> traits = [],
+                     string baseCppClass = "mlir::Type">
+    : TypeDef<HIRDialect, name, traits, baseCppClass> {
+  let mnemonic = ?;
+}
+
+def TypeType : HIRTypeDef<"Type"> {
+  let mnemonic = "type";
+}
+
 #endif // SILICON_DIALECT_HIR_HIRTYPES_TD

--- a/include/silicon/RegisterAll.h
+++ b/include/silicon/RegisterAll.h
@@ -17,6 +17,7 @@
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/Transforms/Passes.h"
 #include "silicon/Dialect/HIR/HIRDialect.h"
+#include "silicon/Dialect/HIR/HIRPasses.h"
 
 namespace silicon {
 
@@ -49,7 +50,7 @@ inline void registerAllPasses() {
   // none
 
   // Register the Silicon passes.
-  // none
+  hir::registerPasses();
 }
 
 } // namespace silicon

--- a/lib/Dialect/HIR/CMakeLists.txt
+++ b/lib/Dialect/HIR/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_silicon_dialect_library(SiliconHIR
   HIRDialect.cpp
+  HIROps.cpp
+  HIRTypes.cpp
 
   LINK_LIBS PUBLIC
   MLIRIR
 )
+
+add_subdirectory(Transforms)

--- a/lib/Dialect/HIR/HIRDialect.cpp
+++ b/lib/Dialect/HIR/HIRDialect.cpp
@@ -7,11 +7,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "silicon/Dialect/HIR/HIRDialect.h"
+#include "silicon/Dialect/HIR/HIROps.h"
+#include "silicon/Dialect/HIR/HIRTypes.h"
 
 using namespace silicon;
 using namespace hir;
 
 void HIRDialect::initialize() {
+  // Register types and attributes.
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "silicon/Dialect/HIR/HIRTypes.cpp.inc"
+      >();
+
   // Register operations.
   addOperations<
 #define GET_OP_LIST

--- a/lib/Dialect/HIR/HIROps.cpp
+++ b/lib/Dialect/HIR/HIROps.cpp
@@ -1,0 +1,13 @@
+//===- HIROps.cpp - High-level IR operations ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "silicon/Dialect/HIR/HIROps.h"
+
+// Pull in the generated dialect definition.
+#define GET_OP_CLASSES
+#include "silicon/Dialect/HIR/HIROps.cpp.inc"

--- a/lib/Dialect/HIR/HIRTypes.cpp
+++ b/lib/Dialect/HIR/HIRTypes.cpp
@@ -1,0 +1,16 @@
+//===- HIROps.cpp - High-level IR operations ------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "silicon/Dialect/HIR/HIRTypes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "silicon/Dialect/HIR/HIRDialect.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+// Pull in the generated type definitions.
+#define GET_TYPEDEF_CLASSES
+#include "silicon/Dialect/HIR/HIRTypes.cpp.inc"

--- a/lib/Dialect/HIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HIR/Transforms/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_silicon_dialect_library(SiliconHIRTransforms
+  InferTypes.cpp
+
+  LINK_LIBS PUBLIC
+  SiliconHIR
+  MLIRIR
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Dialect/HIR/Transforms/InferTypes.cpp
+++ b/lib/Dialect/HIR/Transforms/InferTypes.cpp
@@ -1,0 +1,60 @@
+//===- InferTypes.cpp -----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "silicon/Dialect/HIR/HIROps.h"
+#include "silicon/Dialect/HIR/HIRPasses.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace silicon;
+using namespace hir;
+
+#define DEBUG_TYPE "infer-types"
+
+namespace silicon {
+namespace hir {
+#define GEN_PASS_DEF_INFERTYPESPASS
+#include "silicon/Dialect/HIR/HIRPasses.h.inc"
+} // namespace hir
+} // namespace silicon
+
+namespace {
+struct InferTypesPass : public hir::impl::InferTypesPassBase<InferTypesPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void InferTypesPass::runOnOperation() {
+  SmallVector<UnifyTypeOp> worklist;
+  getOperation()->walk([&](UnifyTypeOp op) { worklist.push_back(op); });
+  LLVM_DEBUG(llvm::dbgs() << "Starting with " << worklist.size()
+                          << " initial unify ops\n");
+
+  while (!worklist.empty()) {
+    auto unifyOp = worklist.pop_back_val();
+    LLVM_DEBUG(llvm::dbgs() << "Processing " << unifyOp << "\n");
+
+    auto lhs = unifyOp.getLhs().getDefiningOp<InferrableTypeOp>();
+    auto rhs = unifyOp.getRhs().getDefiningOp<InferrableTypeOp>();
+    if (!lhs || !rhs)
+      continue;
+
+    auto keepOp = lhs;
+    auto eraseOp = rhs;
+    if (!keepOp->isBeforeInBlock(eraseOp)) {
+      keepOp = rhs;
+      eraseOp = lhs;
+    }
+    LLVM_DEBUG(llvm::dbgs()
+               << "Keeping " << keepOp << ", erasing " << eraseOp << "\n");
+    eraseOp.replaceAllUsesWith(keepOp.getResult());
+    eraseOp.erase();
+    unifyOp.replaceAllUsesWith(keepOp.getResult());
+    unifyOp.erase();
+  }
+}

--- a/test-mlir/Dialect/HIR/basic.mlir
+++ b/test-mlir/Dialect/HIR/basic.mlir
@@ -1,0 +1,14 @@
+// RUN: silicon-opt --verify-roundtrip --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func @Foo
+func.func @Foo(%arg0: !hir.type, %arg1: !hir.type, %arg2: !hir.type) {
+  // CHECK: hir.inferrable_type
+  hir.inferrable_type
+  // CHECK: hir.unify_type %arg0, %arg1
+  hir.unify_type %arg0, %arg1
+  // CHECK: hir.let "x" : %arg0
+  hir.let "x" : %arg0
+  // CHECK: hir.store %arg0, %arg1 : %arg2
+  hir.store %arg0, %arg1 : %arg2
+  return
+}

--- a/test-mlir/Dialect/HIR/infer-types.mlir
+++ b/test-mlir/Dialect/HIR/infer-types.mlir
@@ -1,0 +1,12 @@
+// RUN: silicon-opt --infer-types %s | FileCheck %s
+
+// CHECK: [[T:%.+]] = hir.inferrable_type
+// CHECK: [[X:%.+]] = hir.let "x" : [[T]]
+// CHECK: [[Y:%.+]] = hir.let "y" : [[T]]
+// CHECK: hir.store [[X]], [[Y]] : [[T]]
+%0 = hir.inferrable_type
+%1 = hir.let "x" : %0
+%2 = hir.inferrable_type
+%3 = hir.let "y" : %2
+%4 = hir.unify_type %0, %2
+hir.store %1, %3 : %4


### PR DESCRIPTION
Add a simple `hir.inferrable_type`, `hir.let`, `hir.unify_type`, and `hir.store` operation. These can be used to express a first few type inference problems, for example when assigning the value of one let binding to another.

Also add the InferTypes pass that processes `hir.unify_type` operations in the IR.