### PR TITLE
[InferTypes] Add IntTypeOp, handle inference of concrete types

### DIFF
--- a/include/silicon/Dialect/HIR/HIROps.h
+++ b/include/silicon/Dialect/HIR/HIROps.h
@@ -12,6 +12,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "silicon/Dialect/HIR/HIRTypes.h"
 
 // Pull in the generated dialect definition.

--- a/include/silicon/Dialect/HIR/HIROps.td
+++ b/include/silicon/Dialect/HIR/HIROps.td
@@ -9,15 +9,21 @@
 #ifndef SILICON_DIALECT_HIR_HIROPS_TD
 #define SILICON_DIALECT_HIR_HIROPS_TD
 
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "silicon/Dialect/HIR/HIRDialect.td"
 include "silicon/Dialect/HIR/HIRTypes.td"
-include "mlir/IR/OpBase.td"
 
 // Base class for the operations in this dialect.
 class HIROp<string mnemonic, list<Trait> traits = []> :
   Op<HIRDialect, mnemonic, traits>;
 
 def InferrableTypeOp : HIROp<"inferrable_type", []> {
+  let results = (outs TypeType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def IntTypeOp : HIROp<"int_type", [Pure, ConstantLike]> {
   let results = (outs TypeType:$result);
   let assemblyFormat = "attr-dict";
 }

--- a/test-mlir/Dialect/HIR/basic.mlir
+++ b/test-mlir/Dialect/HIR/basic.mlir
@@ -4,6 +4,8 @@
 func.func @Foo(%arg0: !hir.type, %arg1: !hir.type, %arg2: !hir.type) {
   // CHECK: hir.inferrable_type
   hir.inferrable_type
+  // CHECK: hir.int_type
+  hir.int_type
   // CHECK: hir.unify_type %arg0, %arg1
   hir.unify_type %arg0, %arg1
   // CHECK: hir.let "x" : %arg0

--- a/test-mlir/Dialect/HIR/infer-types.mlir
+++ b/test-mlir/Dialect/HIR/infer-types.mlir
@@ -2,20 +2,54 @@
 
 func.func private @dummy(%arg0: !hir.type)
 
-// CHECK: [[T:%.+]] = hir.inferrable_type {a}
-// CHECK-NOT: hir.inferrable_type {b}
-// CHECK-NOT: hir.unify_type
-// CHECK: func.call @dummy([[T]])
-%0 = hir.inferrable_type {a}
-%1 = hir.inferrable_type {b}
-%2 = hir.unify_type %0, %1
-func.call @dummy(%2) : (!hir.type) -> ()
+// CHECK-LABEL: func @TwoInferrable
+func.func @TwoInferrable() {
+  // CHECK: [[T:%.+]] = hir.inferrable_type {a}
+  // CHECK-NOT: hir.inferrable_type {b}
+  // CHECK-NOT: hir.unify_type
+  // CHECK: call @dummy([[T]])
+  %0 = hir.inferrable_type {a}
+  %1 = hir.inferrable_type {b}
+  %2 = hir.unify_type %0, %1
+  call @dummy(%2) : (!hir.type) -> ()
+  return
+}
 
-// CHECK: [[T:%.+]] = hir.inferrable_type {a}
-// CHECK-NOT: hir.inferrable_type {b}
-// CHECK-NOT: hir.unify_type
-// CHECK: func.call @dummy([[T]])
-%3 = hir.inferrable_type {a}
-%4 = hir.inferrable_type {b}
-%5 = hir.unify_type %4, %3  // reversed
-func.call @dummy(%5) : (!hir.type) -> ()
+// CHECK-LABEL: func @TwoInferrableReversed
+func.func @TwoInferrableReversed() {
+  // CHECK: [[T:%.+]] = hir.inferrable_type {a}
+  // CHECK-NOT: hir.inferrable_type {b}
+  // CHECK-NOT: hir.unify_type
+  // CHECK: call @dummy([[T]])
+  %0 = hir.inferrable_type {a}
+  %1 = hir.inferrable_type {b}
+  %2 = hir.unify_type %1, %0  // reversed
+  call @dummy(%2) : (!hir.type) -> ()
+  return
+}
+
+
+// CHECK-LABEL: func @InferrableAndConcrete1
+func.func @InferrableAndConcrete1() {
+  // CHECK: [[T:%.+]] = hir.int_type
+  // CHECK-NOT: hir.inferrable_type
+  // CHECK-NOT: hir.unify_type
+  // CHECK: call @dummy([[T]])
+  %0 = hir.int_type
+  %1 = hir.inferrable_type
+  %2 = hir.unify_type %0, %1
+  call @dummy(%2) : (!hir.type) -> ()
+  return
+}
+
+// CHECK-LABEL: func @InferrableAndConcrete2
+func.func @InferrableAndConcrete2() {
+  // Cannot infer concrete type if it appears after the inferrable type.
+  // CHECK: hir.inferrable_type
+  // CHECK: hir.int_type
+  %0 = hir.inferrable_type
+  %1 = hir.int_type
+  %2 = hir.unify_type %0, %1
+  call @dummy(%2) : (!hir.type) -> ()
+  return
+}


### PR DESCRIPTION
Add the `hir.int_type` op to construct an unbounded integer type. Extend the InferTypes pass to unify `hir.inferrable_type` ops with concrete `hir.int_type` ops. This only works if the inferrable type appears after the concrete type.

Later on we may want to use a dominance analysis to also allow inference if the concrete type appears before the inferrable type, but dominates all users of the inferrable type. Additionally, we may want to move the concrete type around in the IR to a point where it dominates the inferrable type.