### PR TITLE
[InferTypes] Add RefTypeOp, unify concrete types

### DIFF
--- a/include/silicon/Dialect/HIR/HIROps.td
+++ b/include/silicon/Dialect/HIR/HIROps.td
@@ -28,6 +28,12 @@ def IntTypeOp : HIROp<"int_type", [Pure, ConstantLike]> {
   let assemblyFormat = "attr-dict";
 }
 
+def RefTypeOp : HIROp<"ref_type", [Pure]> {
+  let arguments = (ins TypeType:$innerType);
+  let results = (outs TypeType:$result);
+  let assemblyFormat = "$innerType attr-dict";
+}
+
 def LetOp : HIROp<"let", []> {
   let arguments = (ins StrAttr:$name, TypeType:$type);
   let results = (outs TypeType:$result);

--- a/test-mlir/Dialect/HIR/basic.mlir
+++ b/test-mlir/Dialect/HIR/basic.mlir
@@ -6,6 +6,8 @@ func.func @Foo(%arg0: !hir.type, %arg1: !hir.type, %arg2: !hir.type) {
   hir.inferrable_type
   // CHECK: hir.int_type
   hir.int_type
+  // CHECK: hir.ref_type %arg0
+  hir.ref_type %arg0
   // CHECK: hir.unify_type %arg0, %arg1
   hir.unify_type %arg0, %arg1
   // CHECK: hir.let "x" : %arg0

--- a/test-mlir/Dialect/HIR/infer-types.mlir
+++ b/test-mlir/Dialect/HIR/infer-types.mlir
@@ -8,9 +8,13 @@ func.func @TwoInferrable() {
   // CHECK-NOT: hir.inferrable_type {b}
   // CHECK-NOT: hir.unify_type
   // CHECK: call @dummy([[T]])
+  // CHECK: call @dummy([[T]])
+  // CHECK: call @dummy([[T]])
   %0 = hir.inferrable_type {a}
   %1 = hir.inferrable_type {b}
   %2 = hir.unify_type %0, %1
+  call @dummy(%0) : (!hir.type) -> ()
+  call @dummy(%1) : (!hir.type) -> ()
   call @dummy(%2) : (!hir.type) -> ()
   return
 }
@@ -21,9 +25,13 @@ func.func @TwoInferrableReversed() {
   // CHECK-NOT: hir.inferrable_type {b}
   // CHECK-NOT: hir.unify_type
   // CHECK: call @dummy([[T]])
+  // CHECK: call @dummy([[T]])
+  // CHECK: call @dummy([[T]])
   %0 = hir.inferrable_type {a}
   %1 = hir.inferrable_type {b}
   %2 = hir.unify_type %1, %0  // reversed
+  call @dummy(%0) : (!hir.type) -> ()
+  call @dummy(%1) : (!hir.type) -> ()
   call @dummy(%2) : (!hir.type) -> ()
   return
 }
@@ -35,9 +43,13 @@ func.func @InferrableAndConcrete1() {
   // CHECK-NOT: hir.inferrable_type
   // CHECK-NOT: hir.unify_type
   // CHECK: call @dummy([[T]])
+  // CHECK: call @dummy([[T]])
+  // CHECK: call @dummy([[T]])
   %0 = hir.int_type
   %1 = hir.inferrable_type
   %2 = hir.unify_type %0, %1
+  call @dummy(%0) : (!hir.type) -> ()
+  call @dummy(%1) : (!hir.type) -> ()
   call @dummy(%2) : (!hir.type) -> ()
   return
 }
@@ -51,5 +63,39 @@ func.func @InferrableAndConcrete2() {
   %1 = hir.int_type
   %2 = hir.unify_type %0, %1
   call @dummy(%2) : (!hir.type) -> ()
+  return
+}
+
+// CHECK-LABEL: func @UnifyConcreteOps1
+func.func @UnifyConcreteOps1() {
+  // CHECK-NEXT: [[INT:%.+]] = hir.int_type
+  // CHECK-NEXT: [[REF:%.+]] = hir.ref_type [[INT]]
+  // CHECK-NEXT: call @dummy([[REF]])
+  // CHECK-NEXT: call @dummy([[REF]])
+  // CHECK-NEXT: call @dummy([[REF]])
+  %0 = hir.int_type
+  %1 = hir.inferrable_type
+  %2 = hir.ref_type %0
+  %3 = hir.ref_type %1
+  %4 = hir.unify_type %2, %3
+  call @dummy(%2) : (!hir.type) -> ()
+  call @dummy(%3) : (!hir.type) -> ()
+  call @dummy(%4) : (!hir.type) -> ()
+  return
+}
+
+// CHECK-LABEL: func @UnifyConcreteOps2
+func.func @UnifyConcreteOps2() {
+  // Cannot unify concrete types if the operands of don't dominate both types.
+  // CHECK: hir.int_type
+  // CHECK: hir.ref_type
+  // CHECK: hir.inferrable_type
+  // CHECK: hir.ref_type
+  %0 = hir.int_type
+  %1 = hir.ref_type %0
+  %2 = hir.inferrable_type
+  %3 = hir.ref_type %2
+  %4 = hir.unify_type %1, %3
+  call @dummy(%4) : (!hir.type) -> ()
   return
 }


### PR DESCRIPTION
Add the `hir.ref_type` op to construct a reference type. The op takes the type the reference points to as an operand. Extend the InferTypes pass to unify operations that are equivalent except for their operands. In this case, create new `hir.unify_type` ops, one for each of the operands. This allows us to unify for example two reference types, which will replace one of them with the other and instead create a unification op for the type inside the reference. This is the first step towards proper type inference.