### PR TITLE
[InferTypes] Use DominanceInfo analysis

### DIFF
--- a/test-mlir/Dialect/HIR/infer-types.mlir
+++ b/test-mlir/Dialect/HIR/infer-types.mlir
@@ -99,3 +99,25 @@ func.func @UnifyConcreteOps2() {
   call @dummy(%4) : (!hir.type) -> ()
   return
 }
+
+// CHECK-LABEL: func @InferIfDominates
+func.func @InferIfDominates(%arg0: i1) {
+  // CHECK: [[TMP:%.+]] = hir.int_type
+  %0 = hir.int_type
+  cf.cond_br %arg0, ^bb1, ^bb2
+^bb1:
+  cf.br ^bb3
+^bb2:
+  cf.br ^bb3
+^bb3:
+  // CHECK: ^bb3:
+  // CHECK-NEXT: call @dummy([[TMP]])
+  %1 = hir.inferrable_type
+  %2 = hir.unify_type %0, %1
+  call @dummy(%2) : (!hir.type) -> ()
+  // CHECK-NEXT: call @dummy([[TMP]])
+  %3 = hir.int_type
+  %4 = hir.unify_type %0, %3
+  call @dummy(%4) : (!hir.type) -> ()
+  return
+}


### PR DESCRIPTION
Instead of checking whether an operation `isBeforeInBlock` during type inference, use the `DominanceInfo` analysis. This allows the pass to properly determine which inferrable type dominates the other, especially in the presence of control flow.

Also add a control flow example for type inference.