### PR TITLE
[HIR] Add EvalConsts pass and constant branches

### DIFF
--- a/include/silicon/Dialect/HIR/HIROps.h
+++ b/include/silicon/Dialect/HIR/HIROps.h
@@ -12,6 +12,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "silicon/Dialect/HIR/HIRAttributes.h"

--- a/include/silicon/Dialect/HIR/HIROps.td
+++ b/include/silicon/Dialect/HIR/HIROps.td
@@ -10,8 +10,9 @@
 #define SILICON_DIALECT_HIR_HIROPS_TD
 
 include "mlir/IR/OpBase.td"
-include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "silicon/Dialect/HIR/HIRAttributes.td"
 include "silicon/Dialect/HIR/HIRDialect.td"
 include "silicon/Dialect/HIR/HIRTypes.td"
@@ -60,6 +61,42 @@ def UnifyOp : HIROp<"unify", [
 def StoreOp : HIROp<"store", []> {
   let arguments = (ins TypeType:$target, TypeType:$value, TypeType:$valueType);
   let assemblyFormat = "$target `,` $value `:` $valueType attr-dict";
+}
+
+def ConstBranchOp : HIROp<"const_br", [
+  DeclareOpInterfaceMethods<BranchOpInterface>,
+  Pure,
+  Terminator
+]> {
+  let arguments = (ins Variadic<AnyType>:$destOperands);
+  let successors = (successor AnySuccessor:$dest);
+  let assemblyFormat = [{
+    $dest (`(` $destOperands^ `:` type($destOperands) `)`)?
+    attr-dict
+  }];
+}
+
+def ConstCondBranchOp : HIROp<"const_cond_br", [
+  AttrSizedOperandSegments,
+  DeclareOpInterfaceMethods<BranchOpInterface>,
+  Pure,
+  Terminator
+]> {
+  let arguments = (ins
+    I1:$condition,
+    Variadic<AnyType>:$trueOperands,
+    Variadic<AnyType>:$falseOperands
+  );
+  let successors = (successor
+    AnySuccessor:$trueDest,
+    AnySuccessor:$falseDest
+  );
+  let assemblyFormat = [{
+    $condition `,`
+    $trueDest (`(` $trueOperands^ `:` type($trueOperands) `)`)? `,`
+    $falseDest (`(` $falseOperands^ `:` type($falseOperands) `)`)?
+    attr-dict
+  }];
 }
 
 #endif // SILICON_DIALECT_HIR_HIROPS_TD

--- a/include/silicon/Dialect/HIR/HIRPasses.h
+++ b/include/silicon/Dialect/HIR/HIRPasses.h
@@ -8,13 +8,10 @@
 
 #pragma once
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include <memory>
 #include <optional>
-
-namespace mlir {
-class Pass;
-} // namespace mlir
 
 namespace silicon {
 namespace hir {

--- a/include/silicon/Dialect/HIR/HIRPasses.td
+++ b/include/silicon/Dialect/HIR/HIRPasses.td
@@ -12,7 +12,7 @@
 include "silicon/Dialect/HIR/HIRDialect.td"
 include "mlir/Pass/PassBase.td"
 
-def InferTypesPass : Pass<"infer-types"> {
-}
+def InferTypesPass : Pass<"infer-types">;
+def EvalConstsPass : Pass<"eval-consts", "mlir::func::FuncOp">;
 
 #endif // SILICON_DIALECT_HIR_HIRPASSES_TD

--- a/lib/Dialect/HIR/CMakeLists.txt
+++ b/lib/Dialect/HIR/CMakeLists.txt
@@ -5,7 +5,9 @@ add_silicon_dialect_library(SiliconHIR
   HIRTypes.cpp
 
   LINK_LIBS PUBLIC
+  MLIRFuncDialect
   MLIRIR
+  MLIRControlFlowInterfaces
   MLIRInferTypeOpInterface
   MLIRSideEffectInterfaces
 )

--- a/lib/Dialect/HIR/HIROps.cpp
+++ b/lib/Dialect/HIR/HIROps.cpp
@@ -28,6 +28,17 @@ static void printIntAttr(OpAsmPrinter &printer, Operation *op, IntAttr value) {
   printer << value.getValue();
 }
 
+SuccessorOperands ConstBranchOp::getSuccessorOperands(unsigned index) {
+  assert(index == 0 && "invalid successor index");
+  return SuccessorOperands(getDestOperandsMutable());
+}
+
+SuccessorOperands ConstCondBranchOp::getSuccessorOperands(unsigned index) {
+  assert(index < getNumSuccessors() && "invalid successor index");
+  return SuccessorOperands(index == 0 ? getTrueOperandsMutable()
+                                      : getFalseOperandsMutable());
+}
+
 // Pull in the generated dialect definition.
 #define GET_OP_CLASSES
 #include "silicon/Dialect/HIR/HIROps.cpp.inc"

--- a/lib/Dialect/HIR/Transforms/CMakeLists.txt
+++ b/lib/Dialect/HIR/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_silicon_dialect_library(SiliconHIRTransforms
+  EvalConsts.cpp
   InferTypes.cpp
 
   LINK_LIBS PUBLIC

--- a/lib/Dialect/HIR/Transforms/EvalConsts.cpp
+++ b/lib/Dialect/HIR/Transforms/EvalConsts.cpp
@@ -1,0 +1,242 @@
+//===- EvalConsts.cpp -----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Analysis/Liveness.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "silicon/Dialect/HIR/HIROps.h"
+#include "silicon/Dialect/HIR/HIRPasses.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/GenericIteratedDominanceFrontier.h"
+
+#define DEBUG_TYPE "eval-consts"
+
+using namespace mlir;
+using namespace silicon;
+using namespace hir;
+using llvm::MapVector;
+
+namespace silicon {
+namespace hir {
+#define GEN_PASS_DEF_EVALCONSTSPASS
+#include "silicon/Dialect/HIR/HIRPasses.h.inc"
+} // namespace hir
+} // namespace silicon
+
+static Block *cloneBlock(Block *block, PatternRewriter &rewriter) {
+  IRMapping mapper;
+  auto *clonedBlock = rewriter.createBlock(block);
+  for (auto oldArg : block->getArguments()) {
+    auto newArg = clonedBlock->addArgument(oldArg.getType(), oldArg.getLoc());
+    mapper.map(oldArg, newArg);
+  }
+  for (auto &op : *block)
+    rewriter.clone(op, mapper);
+  return clonedBlock;
+}
+
+namespace {
+struct ConstBranchOpPattern : public OpRewritePattern<ConstBranchOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(ConstBranchOp op,
+                                PatternRewriter &rewriter) const override {
+    LLVM_DEBUG(llvm::dbgs() << "Rewriting " << op << "\n");
+
+    // Clone the destination block if this branch isn't its only use.
+    auto *destBlock = op.getDest();
+    if (!destBlock->hasOneUse())
+      destBlock = cloneBlock(destBlock, rewriter);
+
+    // Remove the branch and append the destination block.
+    auto *thisBlock = op->getBlock();
+    SmallVector<Value> destOperands = op.getDestOperands();
+    rewriter.eraseOp(op);
+    rewriter.mergeBlocks(destBlock, thisBlock, destOperands);
+    return success();
+  }
+};
+
+struct ConstCondBranchOpPattern : public OpRewritePattern<ConstCondBranchOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(ConstCondBranchOp op,
+                                PatternRewriter &rewriter) const override {
+    // Extract the condition value if it is a constant.
+    APInt condition;
+    if (auto *defOp = op.getCondition().getDefiningOp();
+        !defOp || !m_ConstantInt(&condition).match(defOp))
+      return failure();
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "Rewriting " << op << " (condition = " << condition << ")\n");
+
+    // Clone the destination block if this branch isn't its only use.
+    auto *destBlock = condition.isOne() ? op.getTrueDest() : op.getFalseDest();
+    if (!destBlock->hasOneUse())
+      destBlock = cloneBlock(destBlock, rewriter);
+
+    // Remove the branch and append the destination block.
+    auto *thisBlock = op->getBlock();
+    SmallVector<Value> destOperands =
+        condition.isOne() ? op.getTrueOperands() : op.getFalseOperands();
+    rewriter.eraseOp(op);
+    rewriter.mergeBlocks(destBlock, thisBlock, destOperands);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+struct EvalConstsPass : public hir::impl::EvalConstsPassBase<EvalConstsPass> {
+  void runOnOperation() override;
+  void promoteToBlockArguments(Region &region, Liveness &liveness,
+                               DominanceInfo &dominance);
+  void promoteToBlockArguments(Region &region, Value value,
+                               ArrayRef<Operation *> branches,
+                               Liveness &liveness, DominanceInfo &dominance);
+};
+} // namespace
+
+void EvalConstsPass::runOnOperation() {
+  auto *context = &getContext();
+
+  // Promote values that are live across constant branches to block arguments.
+  // This prevents control flow unrolling from creating dominance violations.
+  auto &dominance = getAnalysis<DominanceInfo>();
+  auto &liveness = getAnalysis<Liveness>();
+  for (auto &region : getOperation()->getRegions())
+    promoteToBlockArguments(region, liveness, dominance);
+
+  // Unroll constant branches.
+  RewritePatternSet patterns(context);
+  for (auto *dialect : context->getLoadedDialects())
+    dialect->getCanonicalizationPatterns(patterns);
+  for (auto op : context->getRegisteredOperations())
+    op.getCanonicalizationPatterns(patterns, context);
+  patterns.add<ConstBranchOpPattern>(context);
+  patterns.add<ConstCondBranchOpPattern>(context);
+
+  GreedyRewriteConfig config;
+  config.enableRegionSimplification = GreedySimplifyRegionLevel::Normal;
+
+  if (failed(
+          applyPatternsGreedily(getOperation(), std::move(patterns), config)))
+    return signalPassFailure();
+}
+
+void EvalConstsPass::promoteToBlockArguments(Region &region, Liveness &liveness,
+                                             DominanceInfo &dominance) {
+  if (region.hasOneBlock())
+    return;
+
+  // Collect all values in blocks targeted by constant branches which escape the
+  // block they are defined in. These will have to become block arguments to
+  // allow for branch unrolling to replicate these blocks and values.
+  MapVector<Value, SmallVector<Operation *, 4>> promotableValues;
+  for (auto &block : region) {
+    if (!llvm::any_of(block.getPredecessors(), [&](Block *predecessor) {
+          return isa<ConstBranchOp, ConstCondBranchOp>(
+              predecessor->getTerminator());
+        }))
+      continue;
+    auto *blockLiveness = liveness.getLiveness(&block);
+    for (auto value : block.getArguments())
+      if (blockLiveness->isLiveOut(value))
+        promotableValues[value].push_back(block.getTerminator());
+    for (auto &op : block)
+      for (auto result : op.getResults())
+        if (blockLiveness->isLiveOut(result))
+          promotableValues[result].push_back(block.getTerminator());
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "Promoting " << promotableValues.size()
+                          << " values to block arguments\n");
+  for (auto &[value, branches] : promotableValues)
+    promoteToBlockArguments(region, value, branches, liveness, dominance);
+}
+
+void EvalConstsPass::promoteToBlockArguments(Region &region, Value value,
+                                             ArrayRef<Operation *> branches,
+                                             Liveness &liveness,
+                                             DominanceInfo &dominance) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "Capture " << value << "\n";
+    for (auto *branch : branches)
+      llvm::dbgs() << "- Across " << *branch << "\n";
+  });
+
+  // Calculate the merge points for this value once it gets promoted to block
+  // arguments across the branches.
+  auto &domTree = dominance.getDomTree(&region);
+  llvm::IDFCalculatorBase<Block, false> idfCalculator(domTree);
+
+  // Calculate the set of blocks which will contain a distinct definition of
+  // this value.
+  SmallPtrSet<Block *, 4> definingBlocks;
+  definingBlocks.insert(value.getParentBlock());
+  for (auto *branch : branches)
+    for (auto *dest : branch->getSuccessors())
+      if (liveness.getLiveIn(dest).contains(value))
+        definingBlocks.insert(dest);
+  idfCalculator.setDefiningBlocks(definingBlocks);
+
+  // Calculate where the value is live.
+  SmallPtrSet<Block *, 16> liveInBlocks;
+  for (auto &block : region)
+    if (liveness.getLiveness(&block)->isLiveIn(value))
+      liveInBlocks.insert(&block);
+  idfCalculator.setLiveInBlocks(liveInBlocks);
+
+  // Calculate the merge points where we will have to insert block arguments for
+  // this value.
+  SmallVector<Block *> mergePointsVec;
+  idfCalculator.calculate(mergePointsVec);
+  SmallPtrSet<Block *, 16> mergePoints(mergePointsVec.begin(),
+                                       mergePointsVec.end());
+  for (auto *block : definingBlocks)
+    if (block != value.getParentBlock())
+      mergePoints.insert(block);
+  LLVM_DEBUG(llvm::dbgs() << "- " << mergePoints.size() << " merge points\n");
+
+  // Perform a depth-first search starting at the block containing the value,
+  // which dominates all its uses. When we encounter a block that is a merge
+  // point, insert a block argument.
+  struct WorklistItem {
+    DominanceInfoNode *domNode;
+    Value reachingDef;
+  };
+  SmallVector<WorklistItem> worklist;
+  worklist.push_back({domTree.getNode(value.getParentBlock()), value});
+
+  while (!worklist.empty()) {
+    auto item = worklist.pop_back_val();
+    auto *block = item.domNode->getBlock();
+
+    // If this block is a merge point, insert a block argument for the value.
+    if (mergePoints.contains(block))
+      item.reachingDef = block->addArgument(value.getType(), value.getLoc());
+
+    // Replace any uses of the value in this block with the current reaching
+    // definition.
+    for (auto &op : *block)
+      op.replaceUsesOfWith(value, item.reachingDef);
+
+    // If the terminator of this block branches to a merge point, add the
+    // current reaching definition as a destination operand.
+    if (auto branchOp = dyn_cast<BranchOpInterface>(block->getTerminator()))
+      for (auto &blockOperand : branchOp->getBlockOperands())
+        if (mergePoints.contains(blockOperand.get()))
+          branchOp.getSuccessorOperands(blockOperand.getOperandNumber())
+              .append(item.reachingDef);
+
+    for (auto *child : item.domNode->children())
+      worklist.push_back({child, item.reachingDef});
+  }
+}

--- a/test-mlir/Dialect/HIR/basic.mlir
+++ b/test-mlir/Dialect/HIR/basic.mlir
@@ -1,6 +1,6 @@
 // RUN: silicon-opt --verify-roundtrip --verify-diagnostics %s
 
-func.func @Foo(%arg0: !hir.type, %arg1: !hir.type, %arg2: !hir.type) {
+func.func @Foo(%arg0: !hir.type, %arg1: !hir.type, %arg2: !hir.type, %arg3: i1) {
   hir.constant_int 42
   hir.inferrable : !hir.type
   hir.int_type
@@ -8,6 +8,10 @@ func.func @Foo(%arg0: !hir.type, %arg1: !hir.type, %arg2: !hir.type) {
   hir.unify %arg0, %arg1 : !hir.type
   hir.let "x" : %arg0
   hir.store %arg0, %arg1 : %arg2
+  hir.const_br ^bb1(%arg0 : !hir.type)
+^bb1(%0: !hir.type):
+  hir.const_cond_br %arg3, ^bb1(%0 : !hir.type), ^bb2
+^bb2:
   return
 }
 

--- a/test-mlir/Dialect/HIR/eval-consts.mlir
+++ b/test-mlir/Dialect/HIR/eval-consts.mlir
@@ -1,0 +1,54 @@
+// RUN: silicon-opt --eval-consts %s | FileCheck %s
+
+// CHECK-LABEL: func @UncondBranch
+func.func @UncondBranch(%arg0: i42, %arg1: i42) {
+  // CHECK-NEXT: call @use_i42(%arg0)
+  // CHECK-NEXT: call @use_i42(%arg1)
+  // CHECK-NEXT: return
+  call @use_i42(%arg0) : (i42) -> ()
+  hir.const_br ^bb1(%arg1 : i42)
+^bb1(%0: i42):
+  call @use_i42(%0) : (i42) -> ()
+  return
+}
+
+// CHECK-LABEL: func @CondBranch
+func.func @CondBranch(%arg0: i42, %arg1: i42) {
+  // CHECK-NEXT: call @use_i42(%arg0)
+  // CHECK-NEXT: call @use_i42(%arg1)
+  // CHECK-NEXT: return
+  %false = arith.constant false
+  %true = arith.constant true
+  hir.const_br ^bb1(%false, %arg0 : i1, i42)
+^bb1(%0: i1, %1: i42):
+  call @use_i42(%1) : (i42) -> ()
+  hir.const_cond_br %0, ^bb2, ^bb1(%true, %arg1 : i1, i42)
+^bb2:
+  return
+}
+
+// CHECK-LABEL: func @Loop
+func.func @Loop(%arg0: i42) -> i42 {
+  // CHECK-NEXT: [[T0:%.+]] = call @process_i42(%arg0)
+  // CHECK-NEXT: [[T1:%.+]] = call @process_i42([[T0]])
+  // CHECK-NEXT: [[T2:%.+]] = call @process_i42([[T1]])
+  // CHECK-NEXT: [[T3:%.+]] = call @process_i42([[T2]])
+  // CHECK-NEXT: [[T4:%.+]] = call @process_i42([[T3]])
+  // CHECK-NEXT: [[T5:%.+]] = call @process_i42([[T4]])
+  // CHECK-NEXT: [[T6:%.+]] = call @process_i42([[T5]])
+  // CHECK-NEXT: [[T7:%.+]] = call @process_i42([[T6]])
+  // CHECK-NEXT: return [[T7]]
+  %c1_index = arith.constant 1 : index
+  %c8_index = arith.constant 8 : index
+  hir.const_br ^bb1(%c1_index, %arg0 : index, i42)
+^bb1(%0: index, %1: i42):
+  %2 = call @process_i42(%1) : (i42) -> i42
+  %3 = arith.addi %0, %c1_index : index
+  %4 = arith.cmpi ult, %0, %c8_index : index
+  hir.const_cond_br %4, ^bb1(%3, %2 : index, i42), ^bb2(%2 : i42)
+^bb2(%5: i42):
+  return %5 : i42
+}
+
+func.func private @use_i42(%x: i42)
+func.func private @process_i42(%x: i42) -> i42


### PR DESCRIPTION
Add the EvalConsts pass which fully unrolls any constant control flow operations in the IR. Also add a `hir.const_br` and `hir.const_cond_br` operation to encode constant control flow. These currently operate on regular i1 conditions, which may not be constant. In the future, we'll want to accept a specific `!hir.const<i1>` type wrapper to enfroce that the conditions are known at compile time.

Also add a few tests, including a loop test which shows that constant control flow can be used to implement a static for loop similar to the following:

    fn foo(a: uint<42>) -> uint<42> {
      let x = a;
      const for i in 0..8 {
        x = process(x);
      }
      return x;
    }