### PR TITLE
[docs] Generate website using Hugo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   #===----------------------------------------------------------------------===#
   # Sanity Check
@@ -126,6 +131,13 @@ jobs:
           key: short-${{ matrix.compiler.cc }}-${{ matrix.build-type }}-${{ matrix.build-shared }}-${{ matrix.build-assert }}
           max-size: 500M
 
+      # Install Hugo for website build.
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: latest
+          extended: true
+
       # Configure the build
       - name: Configure
         run: |
@@ -149,11 +161,18 @@ jobs:
 
       # Build everything
       - name: Build
-        run: ninja -C build silicon
+        run: ninja -C build silicon silicon-website
 
       # Run the tests
       - name: Tests
         run: ninja -C build check-silicon
+
+      # Upload the built website as an artifact. (Only for the clang build.)
+      - name: Upload Website
+        if: matrix.compiler.cc == 'clang'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/website
 
       # Choose the git commit to diff against for the purposes of linting.
       # Since this workflow is triggered on both pushes and pull requests, we
@@ -212,3 +231,19 @@ jobs:
         with:
           name: clang-tidy-patches
           path: clang-*.patch
+
+  #===----------------------------------------------------------------------===#
+  # Deploy Website
+  #===----------------------------------------------------------------------===#
+  deploy-website:
+    name: Deploy Website
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,6 @@
     url = https://github.com/llvm/circt.git
     shallow = true
     branch = main
+[submodule "docs/themes/hugo-book"]
+	path = docs/themes/hugo-book
+	url = https://github.com/alex-shpak/hugo-book

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Run the build:
 ninja -C build check-silicon      # build and run all tests
 ninja -C build silicon            # build everything
 ninja -C build silicon-docs       # build documentation
+ninja -C build silicon-website    # build website (requires hugo)
 ninja -C build silicon-tools      # build tools such as silc and silicon-opt
 ninja -C build silicon-libraries  # build everything else
 ```

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -24,6 +24,7 @@ collect_doc(internals/passes/Transforms.md include/silicon/Transforms/Passes.md)
 
 # Static documents
 file(GLOB_RECURSE static_docs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.md)
+list(FILTER static_docs EXCLUDE REGEX "^themes/")
 foreach(doc ${static_docs})
   collect_doc(${doc} docs/${doc})
 endforeach()
@@ -31,3 +32,18 @@ endforeach()
 # Collect these documents as part of the silicon-docs target.
 add_custom_target(SiliconDocFiles DEPENDS ${collected_docs})
 add_dependencies(silicon-docs SiliconDocFiles)
+
+# Build the website with Hugo. We copy hugo.toml and symlink the theme into
+# the build docs directory, so Hugo runs entirely inside the build tree.
+find_program(HUGO hugo)
+if(HUGO)
+  add_custom_target(silicon-website
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/hugo.toml ${dstdir}/hugo.toml
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/themes ${dstdir}/themes
+    COMMAND ${HUGO} --source ${dstdir} --destination ${CMAKE_BINARY_DIR}/website
+    COMMENT "Building website"
+  )
+  add_dependencies(silicon-website silicon-docs)
+else()
+  message(STATUS "Hugo not found; silicon-website target will not be available")
+endif()

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,10 @@
+---
+title: Silicon
+type: docs
+---
+
+# Silicon
+
+An experimental hardware description language and compiler, built on top of [CIRCT](https://circt.llvm.org/), [MLIR](https://mlir.llvm.org/), and [LLVM](https://llvm.org/).
+
+Silicon aims to create a modern language with an ergonomic syntax inspired by Rust and Zig, which allows for rich metaprogramming in the language itself through phased execution.

--- a/docs/collect.py
+++ b/docs/collect.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
+
+# # Collect Documentation
+#
+# Copies a documentation file from a source to a destination, applying
+# transformations needed for Hugo along the way:
+# - Strips `[TOC]` markers (Hugo Book renders TOC automatically).
+# - Injects YAML front matter if missing. The title is extracted from the first
+#   `# Heading` line, falling back to the filename stem.
+
 import argparse
-import shutil
+import re
 import sys
 from pathlib import Path
 
@@ -22,5 +31,18 @@ else:
         print(f"  {path}", file=sys.stderr)
     sys.exit(1)
 
+text = src.read_text()
+
+# Strip [TOC] markers. Hugo Book renders the table of contents automatically.
+text = re.sub(r"^\[TOC\]\s*$", "", text, flags=re.MULTILINE)
+
+# Inject YAML front matter if missing.
+if not text.startswith("---"):
+    title = args.dst.stem
+    match = re.search(r"^#\s+(.+)$", text, re.MULTILINE)
+    if match:
+        title = match.group(1).strip()
+    text = f"---\ntitle: \"{title}\"\n---\n\n{text}"
+
 args.dst.parent.mkdir(parents=True, exist_ok=True)
-shutil.copy2(src, args.dst)
+args.dst.write_text(text)

--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -1,0 +1,3 @@
+# Design
+
+Design documents describing the goals and architecture of the Silicon language and compiler.

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,0 +1,10 @@
+baseURL = "https://silicon-org.github.io/silicon/"
+title = "Silicon"
+theme = "hugo-book"
+contentDir = "."
+
+disableKinds = ["taxonomy"]
+ignoreFiles = ['cmake_install\.cmake$', 'CMakeFiles']
+
+[markup.goldmark.renderer]
+unsafe = true

--- a/docs/internals/_index.md
+++ b/docs/internals/_index.md
@@ -1,0 +1,3 @@
+# Internals
+
+Documentation of the Silicon compiler internals, including its IR dialects and transformation passes.

--- a/docs/internals/dialects/_index.md
+++ b/docs/internals/dialects/_index.md
@@ -1,0 +1,3 @@
+# Dialects
+
+Silicon uses MLIR dialects to represent hardware designs at different levels of abstraction.

--- a/docs/internals/passes/_index.md
+++ b/docs/internals/passes/_index.md
@@ -1,0 +1,3 @@
+# Passes
+
+Transformation and conversion passes in the Silicon compiler.


### PR DESCRIPTION
Add a Hugo setup to `docs/` and corresponding build targets that invoke Hugo to turn the documentation collected by `silicon-docs` into a website when invoked via `silicon-website`.

Extend CI a bit to always generate the documentation website, and deploy specifically the one generated by the Clang build. This will later allow us to use clang-doc.