### PR TITLE
Add split_func, multiphase_func, opaque IR ops

### DIFF
--- a/include/silicon/HIR/Ops.td
+++ b/include/silicon/HIR/Ops.td
@@ -372,4 +372,100 @@ def UnifiedCallOp : HIROp<"unified_call", [
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Split Functions and Phase Management
+//===----------------------------------------------------------------------===//
+
+def SignatureOp : HIROp<"signature", [
+  AttrSizedOperandSegments,
+  HasParent<"SplitFuncOp">,
+  Pure,
+  Terminator,
+]> {
+  let summary = "Terminator for the signature region of a split function";
+  let arguments = (ins
+    Variadic<AnyHIRType>:$typeOfArgs,
+    Variadic<AnyHIRType>:$typeOfResults
+  );
+  let assemblyFormat = [{
+    ` ` `(` $typeOfArgs `)` `->` `(` $typeOfResults `)` attr-dict
+  }];
+}
+
+def SplitFuncOp : HIROp<"split_func", [
+  IsolatedFromAbove,
+  Symbol,
+]> {
+  let summary = "Records how a unified function was split into per-phase functions";
+  let description = [{
+    A `hir.split_func` records the result of splitting a `hir.unified_func`
+    into separate per-phase functions. It preserves the original function's
+    signature (for library callers) and maps phase numbers to the generated
+    per-phase `hir.func` ops.
+  }];
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    OptionalAttr<StrAttr>:$sym_visibility,
+    ArrayAttr:$argNames,
+    DenseI32ArrayAttr:$argPhases,
+    ArrayAttr:$resultNames,
+    DenseI32ArrayAttr:$resultPhases,
+    DenseI32ArrayAttr:$phaseNumbers,
+    ArrayAttr:$phaseFuncs
+  );
+  let regions = (region MinSizedRegion<1>:$signature);
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
+  let extraClassDeclaration = [{
+    SignatureOp getSignatureOp();
+  }];
+}
+
+def MultiphaseFuncOp : HIROp<"multiphase_func", [
+  Symbol,
+]> {
+  let summary = "A chain of sub-functions evaluated iteratively, one phase at a time";
+  let description = [{
+    A `hir.multiphase_func` represents a single phase of a split function that
+    itself spans multiple internal sub-phases. The sub-functions are evaluated
+    in order. Arguments are marked `first` or `last` to indicate whether they
+    are available from the first or last sub-phase.
+  }];
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    OptionalAttr<StrAttr>:$sym_visibility,
+    ArrayAttr:$argNames,
+    DenseBoolArrayAttr:$argIsFirst,
+    ArrayAttr:$resultNames,
+    ArrayAttr:$phaseFuncs
+  );
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Opaque Bundles
+//===----------------------------------------------------------------------===//
+
+def OpaqueTypeOp : HIROp<"opaque_type", [Pure]> {
+  let summary = "Type constructor for opaque bundles";
+  let results = (outs AnyHIRType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def OpaquePackOp : HIROp<"opaque_pack", [Pure]> {
+  let summary = "Pack multiple values into a single opaque bundle";
+  let arguments = (ins Variadic<AnyHIRType>:$operands);
+  let results = (outs AnyHIRType:$result);
+  let assemblyFormat = [{ `(` $operands `)` attr-dict }];
+}
+
+def OpaqueUnpackOp : HIROp<"opaque_unpack", [Pure]> {
+  let summary = "Unpack an opaque bundle into individual values";
+  let arguments = (ins AnyHIRType:$input);
+  let results = (outs Variadic<AnyHIRType>:$results);
+  let assemblyFormat = [{ $input attr-dict `:` type($results) }];
+}
+
 #endif // SILICON_HIR_OPS_TD

--- a/include/silicon/MIR/Ops.td
+++ b/include/silicon/MIR/Ops.td
@@ -85,4 +85,26 @@ def CallOp : MIROp<"call"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Opaque Bundles
+//===----------------------------------------------------------------------===//
+
+def MIROpaquePackOp : MIROp<"opaque_pack", [Pure]> {
+  let summary = "Pack multiple values into a single opaque bundle";
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let results = (outs OpaqueType:$result);
+  let assemblyFormat = [{
+    `(` $operands `)` `:` `(` type($operands) `)` attr-dict
+  }];
+}
+
+def MIROpaqueUnpackOp : MIROp<"opaque_unpack", [Pure]> {
+  let summary = "Unpack an opaque bundle into individual values";
+  let arguments = (ins OpaqueType:$input);
+  let results = (outs Variadic<AnyType>:$results);
+  let assemblyFormat = [{
+    $input `:` type($results) attr-dict
+  }];
+}
+
 #endif // SILICON_MIR_OPS_TD

--- a/include/silicon/MIR/Types.td
+++ b/include/silicon/MIR/Types.td
@@ -52,4 +52,9 @@ def SpecializedFuncType : MIRTypeDef<"SpecializedFunc"> {
   let summary = "specialized function";
 }
 
+def OpaqueType : MIRTypeDef<"Opaque"> {
+  let mnemonic = "opaque";
+  let summary = "opaque value bundle passed between phases";
+}
+
 #endif // SILICON_MIR_TYPES_TD

--- a/lib/HIR/Ops.cpp
+++ b/lib/HIR/Ops.cpp
@@ -46,6 +46,344 @@ SuccessorOperands ConstCondBranchOp::getSuccessorOperands(unsigned index) {
 #include "silicon/HIR/Ops.cpp.inc"
 
 //===----------------------------------------------------------------------===//
+// SplitFuncOp
+//===----------------------------------------------------------------------===//
+
+// # Custom Parser for SplitFuncOp
+//
+// The assembly format is:
+//   hir.split_func @name(arg: phase, ...) -> (result: phase, ...) {
+//     <signature region>
+//   } [phase: @sym, ...]
+//
+// The parser extracts named+phased argument/result lists and a phase-to-symbol
+// map, storing them as properties on the op.
+
+ParseResult SplitFuncOp::parse(OpAsmParser &parser, OperationState &result) {
+  auto &props = result.getOrAddProperties<SplitFuncOp::Properties>();
+  auto *ctx = parser.getContext();
+  auto builder = OpBuilder(ctx);
+
+  // Parse optional visibility.
+  StringAttr visAttr;
+  if (parseSymbolVisibility(parser, visAttr))
+    return failure();
+  if (visAttr)
+    props.sym_visibility = visAttr;
+
+  // Parse symbol name.
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr))
+    return failure();
+  props.sym_name = nameAttr;
+
+  // Parse argument list: (name: phase, ...).
+  SmallVector<Attribute> argNames;
+  SmallVector<int32_t> argPhases;
+  if (parser.parseLParen())
+    return failure();
+  if (failed(parser.parseOptionalRParen())) {
+    do {
+      std::string name;
+      int32_t phase;
+      if (parser.parseKeywordOrString(&name) || parser.parseColon() ||
+          parser.parseInteger(phase))
+        return failure();
+      argNames.push_back(builder.getStringAttr(name));
+      argPhases.push_back(phase);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRParen())
+      return failure();
+  }
+  props.argNames = builder.getArrayAttr(argNames);
+  props.argPhases = builder.getDenseI32ArrayAttr(argPhases);
+
+  // Parse result list: -> (name: phase, ...).
+  SmallVector<Attribute> resultNames;
+  SmallVector<int32_t> resultPhases;
+  if (parser.parseArrow() || parser.parseLParen())
+    return failure();
+  if (failed(parser.parseOptionalRParen())) {
+    do {
+      std::string name;
+      int32_t phase;
+      if (parser.parseKeywordOrString(&name) || parser.parseColon() ||
+          parser.parseInteger(phase))
+        return failure();
+      resultNames.push_back(builder.getStringAttr(name));
+      resultPhases.push_back(phase);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRParen())
+      return failure();
+  }
+  props.resultNames = builder.getArrayAttr(resultNames);
+  props.resultPhases = builder.getDenseI32ArrayAttr(resultPhases);
+
+  // Parse signature region.
+  auto *region = result.addRegion();
+  if (parser.parseRegion(*region))
+    return failure();
+
+  // Parse phase map: [phase: @sym, ...].
+  SmallVector<int32_t> phaseNumbers;
+  SmallVector<Attribute> phaseFuncs;
+  if (parser.parseLSquare())
+    return failure();
+  if (failed(parser.parseOptionalRSquare())) {
+    do {
+      int32_t phase;
+      FlatSymbolRefAttr sym;
+      if (parser.parseInteger(phase) || parser.parseColon() ||
+          parser.parseAttribute(sym))
+        return failure();
+      phaseNumbers.push_back(phase);
+      phaseFuncs.push_back(sym);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRSquare())
+      return failure();
+  }
+  props.phaseNumbers = builder.getDenseI32ArrayAttr(phaseNumbers);
+  props.phaseFuncs = builder.getArrayAttr(phaseFuncs);
+
+  return success();
+}
+
+void SplitFuncOp::print(OpAsmPrinter &p) {
+  p << ' ';
+  printSymbolVisibility(p, *this, getSymVisibilityAttr());
+  p.printSymbolName(getSymName());
+
+  // Print argument list.
+  p << '(';
+  auto argNames = getArgNames();
+  auto argPhases = getArgPhases();
+  for (size_t i = 0, e = argNames.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << cast<StringAttr>(argNames[i]).getValue() << ": " << argPhases[i];
+  }
+  p << ')';
+
+  // Print result list.
+  p << " -> (";
+  auto resultNames = getResultNames();
+  auto resultPhases = getResultPhases();
+  for (size_t i = 0, e = resultNames.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << cast<StringAttr>(resultNames[i]).getValue() << ": " << resultPhases[i];
+  }
+  p << ") ";
+
+  // Print signature region.
+  p.printRegion(getSignature());
+
+  // Print phase map, one entry per line.
+  p << " [";
+  auto phaseNumbers = getPhaseNumbers();
+  auto phaseFuncs = getPhaseFuncs();
+  for (size_t i = 0, e = phaseNumbers.size(); i < e; ++i) {
+    if (i)
+      p << ',';
+    p.printNewline();
+    p << "  " << phaseNumbers[i] << ": ";
+    p.printAttribute(phaseFuncs[i]);
+  }
+  p.printNewline();
+  p << ']';
+}
+
+LogicalResult SplitFuncOp::verify() {
+  if (getArgPhases().size() != getArgNames().size())
+    return emitOpError() << "argPhases has " << getArgPhases().size()
+                         << " entries but function has " << getArgNames().size()
+                         << " arguments";
+
+  if (getResultPhases().size() != getResultNames().size())
+    return emitOpError() << "resultPhases has " << getResultPhases().size()
+                         << " entries but function has "
+                         << getResultNames().size() << " results";
+
+  if (getPhaseNumbers().size() != getPhaseFuncs().size())
+    return emitOpError() << "phaseNumbers has " << getPhaseNumbers().size()
+                         << " entries but phaseFuncs has "
+                         << getPhaseFuncs().size() << " entries";
+
+  // Verify the signature terminator's operand counts match.
+  auto sigOp = dyn_cast<SignatureOp>(getSignature().back().getTerminator());
+  if (!sigOp)
+    return success(); // verifyRegions will catch missing terminator
+
+  if (sigOp.getTypeOfArgs().size() != getArgNames().size())
+    return emitOpError() << "signature has " << sigOp.getTypeOfArgs().size()
+                         << " argument types but function has "
+                         << getArgNames().size() << " arguments";
+
+  if (sigOp.getTypeOfResults().size() != getResultNames().size())
+    return emitOpError() << "signature has " << sigOp.getTypeOfResults().size()
+                         << " result types but function has "
+                         << getResultNames().size() << " results";
+
+  return success();
+}
+
+LogicalResult SplitFuncOp::verifyRegions() {
+  if (!isa<SignatureOp>(getSignature().back().getTerminator()))
+    return emitOpError()
+           << "requires `hir.signature` terminator in the signature";
+  return success();
+}
+
+SignatureOp SplitFuncOp::getSignatureOp() {
+  return cast<SignatureOp>(getSignature().back().getTerminator());
+}
+
+//===----------------------------------------------------------------------===//
+// MultiphaseFuncOp
+//===----------------------------------------------------------------------===//
+
+// # Custom Parser for MultiphaseFuncOp
+//
+// The assembly format is:
+//   hir.multiphase_func @name(last arg, first arg, ...) -> (result, ...) [
+//     @sym, ...
+//   ]
+//
+// Each argument is preceded by `first` or `last` to indicate whether it
+// originates from the first or last sub-phase.
+
+ParseResult MultiphaseFuncOp::parse(OpAsmParser &parser,
+                                    OperationState &result) {
+  auto &props = result.getOrAddProperties<MultiphaseFuncOp::Properties>();
+  auto *ctx = parser.getContext();
+  auto builder = OpBuilder(ctx);
+
+  // Parse optional visibility.
+  StringAttr visAttr;
+  if (parseSymbolVisibility(parser, visAttr))
+    return failure();
+  if (visAttr)
+    props.sym_visibility = visAttr;
+
+  // Parse symbol name.
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr))
+    return failure();
+  props.sym_name = nameAttr;
+
+  // Parse argument list: ((first|last) name, ...).
+  SmallVector<Attribute> argNames;
+  SmallVector<bool> argIsFirst;
+  if (parser.parseLParen())
+    return failure();
+  if (failed(parser.parseOptionalRParen())) {
+    do {
+      StringRef keyword;
+      std::string name;
+      if (parser.parseKeyword(&keyword))
+        return failure();
+      if (keyword != "first" && keyword != "last")
+        return parser.emitError(parser.getCurrentLocation(),
+                                "expected 'first' or 'last'");
+      if (parser.parseKeywordOrString(&name))
+        return failure();
+      argNames.push_back(builder.getStringAttr(name));
+      argIsFirst.push_back(keyword == "first");
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRParen())
+      return failure();
+  }
+  props.argNames = builder.getArrayAttr(argNames);
+  props.argIsFirst = builder.getDenseBoolArrayAttr(argIsFirst);
+
+  // Parse result list: -> (name, ...).
+  SmallVector<Attribute> resultNames;
+  if (parser.parseArrow() || parser.parseLParen())
+    return failure();
+  if (failed(parser.parseOptionalRParen())) {
+    do {
+      std::string name;
+      if (parser.parseKeywordOrString(&name))
+        return failure();
+      resultNames.push_back(builder.getStringAttr(name));
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRParen())
+      return failure();
+  }
+  props.resultNames = builder.getArrayAttr(resultNames);
+
+  // Parse function list: [@sym, ...].
+  SmallVector<Attribute> phaseFuncs;
+  if (parser.parseLSquare())
+    return failure();
+  if (failed(parser.parseOptionalRSquare())) {
+    do {
+      FlatSymbolRefAttr sym;
+      if (parser.parseAttribute(sym))
+        return failure();
+      phaseFuncs.push_back(sym);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRSquare())
+      return failure();
+  }
+  props.phaseFuncs = builder.getArrayAttr(phaseFuncs);
+
+  return success();
+}
+
+void MultiphaseFuncOp::print(OpAsmPrinter &p) {
+  p << ' ';
+  printSymbolVisibility(p, *this, getSymVisibilityAttr());
+  p.printSymbolName(getSymName());
+
+  // Print argument list.
+  p << '(';
+  auto argNames = getArgNames();
+  auto argIsFirst = getArgIsFirst();
+  for (size_t i = 0, e = argNames.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << (argIsFirst[i] ? "first" : "last") << ' '
+      << cast<StringAttr>(argNames[i]).getValue();
+  }
+  p << ')';
+
+  // Print result list.
+  p << " -> (";
+  auto resultNames = getResultNames();
+  for (size_t i = 0, e = resultNames.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << cast<StringAttr>(resultNames[i]).getValue();
+  }
+  p << ") [";
+
+  // Print function list, one entry per line.
+  auto phaseFuncs = getPhaseFuncs();
+  for (size_t i = 0, e = phaseFuncs.size(); i < e; ++i) {
+    if (i)
+      p << ',';
+    p.printNewline();
+    p << "  ";
+    p.printAttribute(phaseFuncs[i]);
+  }
+  p.printNewline();
+  p << ']';
+}
+
+LogicalResult MultiphaseFuncOp::verify() {
+  if (getArgIsFirst().size() != getArgNames().size())
+    return emitOpError() << "argIsFirst has " << getArgIsFirst().size()
+                         << " entries but function has " << getArgNames().size()
+                         << " arguments";
+
+  if (getPhaseFuncs().empty())
+    return emitOpError() << "phaseFuncs must have at least one entry";
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // CallOp
 //===----------------------------------------------------------------------===//
 

--- a/test/HIR/basic.mlir
+++ b/test/HIR/basic.mlir
@@ -68,3 +68,41 @@ hir.expr : !hir.any, !hir.any {
   %1 = hir.anyfunc_type
   hir.yield %0, %1 : !hir.any, !hir.any
 }
+
+// split_func with args, results, signature, and phase map
+hir.split_func @SplitExample(a: -3, b: -1) -> (c: 0) {
+^bb0(%a_arg: !hir.any, %b_arg: !hir.any):
+  %st0 = hir.int_type
+  hir.signature (%st0, %st0) -> (%st0)
+} [
+  -3: @SplitExample.0,
+  -1: @SplitExample.1,
+  0: @SplitExample.2
+]
+
+// split_func with no args/results
+hir.split_func @SplitNoArgs() -> () {
+  hir.signature () -> ()
+} [
+  0: @SplitNoArgs.0
+]
+
+// multiphase_func with first/last args
+hir.multiphase_func @Multi(last a, first b) -> (out) [
+  @Multi.0,
+  @Multi.1
+]
+
+// multiphase_func with no args
+hir.multiphase_func @MultiNoArgs() -> (out) [
+  @MultiNoArgs.0,
+  @MultiNoArgs.1,
+  @MultiNoArgs.2
+]
+
+// opaque ops
+hir.opaque_type
+%opaque_a = hir.int_type
+%opaque_b = hir.constant_int 42
+%packed = hir.opaque_pack (%opaque_a, %opaque_b)
+%unp_x, %unp_y = hir.opaque_unpack %packed : !hir.any, !hir.any

--- a/test/HIR/errors.mlir
+++ b/test/HIR/errors.mlir
@@ -179,3 +179,40 @@ hir.unified_func @foo [0] -> [0] attributes {argNames = ["a"]} {
 %int_type = hir.int_type
 // expected-error @below {{typeOfResults has 0 entries but call has 1 results}}
 %2 = hir.unified_call @foo(%arg) : (%int_type) -> () (!hir.any) -> !hir.any [0] -> [0]
+
+// -----
+
+// expected-error @below {{requires `hir.signature` terminator in the signature}}
+hir.split_func @bad_term() -> () {
+^bb0:
+  hir.const_br ^bb1
+^bb1:
+  hir.const_br ^bb1
+} [
+  0: @bad_term.0
+]
+
+// -----
+
+// expected-error @below {{signature has 1 argument types but function has 0 arguments}}
+hir.split_func @bad_sig_args() -> () {
+  %0 = hir.int_type
+  hir.signature (%0) -> ()
+} [
+  0: @bad_sig_args.0
+]
+
+// -----
+
+// expected-error @below {{signature has 1 result types but function has 0 results}}
+hir.split_func @bad_sig_results() -> () {
+  %0 = hir.int_type
+  hir.signature () -> (%0)
+} [
+  0: @bad_sig_results.0
+]
+
+// -----
+
+// expected-error @below {{phaseFuncs must have at least one entry}}
+hir.multiphase_func @empty_phases() -> (out) []

--- a/test/MIR/basic.mlir
+++ b/test/MIR/basic.mlir
@@ -39,3 +39,10 @@ func.func @Return2(%arg0: !mir.type, %arg1: !mir.int) {
 mir.call @foo() : () -> ()
 mir.call @foo(%int_type) : (!mir.type) -> (!mir.type)
 mir.call @foo(%int_type, %c42_int) : (!mir.type, !mir.int) -> (!mir.type, !mir.int)
+
+// Opaque type
+unrealized_conversion_cast to !mir.opaque
+
+// Opaque pack/unpack
+%opaque_ctx = mir.opaque_pack (%c42_int, %int_type) : (!mir.int, !mir.type)
+%opaque_a, %opaque_b = mir.opaque_unpack %opaque_ctx : !mir.int, !mir.type


### PR DESCRIPTION
Add new HIR ops for the phase-split IR representation:

- `hir.signature`: terminator for split_func signature regions
- `hir.split_func`: records how a unified function was split into per-phase functions, preserving the original signature and a phase-to-symbol map
- `hir.multiphase_func`: a chain of sub-functions evaluated one phase at a time, with first/last argument annotations
- `hir.opaque_type`, `hir.opaque_pack`, `hir.opaque_unpack`: type constructor and pack/unpack ops for opaque value bundles passed between phases

Add corresponding MIR ops and types:

- `!mir.opaque`: opaque value bundle type
- `mir.opaque_pack`, `mir.opaque_unpack`: typed pack/unpack ops

Includes custom parsers/printers for split_func and multiphase_func, verifiers, roundtrip tests, and error tests.