### PR TITLE
Emit split_func, multiphase_func in SplitPhases

### DIFF
--- a/include/silicon/HIR/Ops.td
+++ b/include/silicon/HIR/Ops.td
@@ -372,4 +372,100 @@ def UnifiedCallOp : HIROp<"unified_call", [
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Split Functions and Phase Management
+//===----------------------------------------------------------------------===//
+
+def SignatureOp : HIROp<"signature", [
+  AttrSizedOperandSegments,
+  HasParent<"SplitFuncOp">,
+  Pure,
+  Terminator,
+]> {
+  let summary = "Terminator for the signature region of a split function";
+  let arguments = (ins
+    Variadic<AnyHIRType>:$typeOfArgs,
+    Variadic<AnyHIRType>:$typeOfResults
+  );
+  let assemblyFormat = [{
+    ` ` `(` $typeOfArgs `)` `->` `(` $typeOfResults `)` attr-dict
+  }];
+}
+
+def SplitFuncOp : HIROp<"split_func", [
+  IsolatedFromAbove,
+  Symbol,
+]> {
+  let summary = "Records how a unified function was split into per-phase functions";
+  let description = [{
+    A `hir.split_func` records the result of splitting a `hir.unified_func`
+    into separate per-phase functions. It preserves the original function's
+    signature (for library callers) and maps phase numbers to the generated
+    per-phase `hir.func` ops.
+  }];
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    OptionalAttr<StrAttr>:$sym_visibility,
+    ArrayAttr:$argNames,
+    DenseI32ArrayAttr:$argPhases,
+    ArrayAttr:$resultNames,
+    DenseI32ArrayAttr:$resultPhases,
+    DenseI32ArrayAttr:$phaseNumbers,
+    ArrayAttr:$phaseFuncs
+  );
+  let regions = (region MinSizedRegion<1>:$signature);
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+  let hasRegionVerifier = 1;
+  let extraClassDeclaration = [{
+    SignatureOp getSignatureOp();
+  }];
+}
+
+def MultiphaseFuncOp : HIROp<"multiphase_func", [
+  Symbol,
+]> {
+  let summary = "A chain of sub-functions evaluated iteratively, one phase at a time";
+  let description = [{
+    A `hir.multiphase_func` represents a single phase of a split function that
+    itself spans multiple internal sub-phases. The sub-functions are evaluated
+    in order. Arguments are marked `first` or `last` to indicate whether they
+    are available from the first or last sub-phase.
+  }];
+  let arguments = (ins
+    SymbolNameAttr:$sym_name,
+    OptionalAttr<StrAttr>:$sym_visibility,
+    ArrayAttr:$argNames,
+    DenseBoolArrayAttr:$argIsFirst,
+    ArrayAttr:$resultNames,
+    ArrayAttr:$phaseFuncs
+  );
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Opaque Bundles
+//===----------------------------------------------------------------------===//
+
+def OpaqueTypeOp : HIROp<"opaque_type", [Pure]> {
+  let summary = "Type constructor for opaque bundles";
+  let results = (outs AnyHIRType:$result);
+  let assemblyFormat = "attr-dict";
+}
+
+def OpaquePackOp : HIROp<"opaque_pack", [Pure]> {
+  let summary = "Pack multiple values into a single opaque bundle";
+  let arguments = (ins Variadic<AnyHIRType>:$operands);
+  let results = (outs AnyHIRType:$result);
+  let assemblyFormat = [{ `(` $operands `)` attr-dict }];
+}
+
+def OpaqueUnpackOp : HIROp<"opaque_unpack", [Pure]> {
+  let summary = "Unpack an opaque bundle into individual values";
+  let arguments = (ins AnyHIRType:$input);
+  let results = (outs Variadic<AnyHIRType>:$results);
+  let assemblyFormat = [{ $input attr-dict `:` type($results) }];
+}
+
 #endif // SILICON_HIR_OPS_TD

--- a/include/silicon/MIR/Ops.td
+++ b/include/silicon/MIR/Ops.td
@@ -85,4 +85,26 @@ def CallOp : MIROp<"call"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Opaque Bundles
+//===----------------------------------------------------------------------===//
+
+def MIROpaquePackOp : MIROp<"opaque_pack", [Pure]> {
+  let summary = "Pack multiple values into a single opaque bundle";
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let results = (outs OpaqueType:$result);
+  let assemblyFormat = [{
+    `(` $operands `)` `:` `(` type($operands) `)` attr-dict
+  }];
+}
+
+def MIROpaqueUnpackOp : MIROp<"opaque_unpack", [Pure]> {
+  let summary = "Unpack an opaque bundle into individual values";
+  let arguments = (ins OpaqueType:$input);
+  let results = (outs Variadic<AnyType>:$results);
+  let assemblyFormat = [{
+    $input `:` type($results) attr-dict
+  }];
+}
+
 #endif // SILICON_MIR_OPS_TD

--- a/include/silicon/MIR/Types.td
+++ b/include/silicon/MIR/Types.td
@@ -52,4 +52,9 @@ def SpecializedFuncType : MIRTypeDef<"SpecializedFunc"> {
   let summary = "specialized function";
 }
 
+def OpaqueType : MIRTypeDef<"Opaque"> {
+  let mnemonic = "opaque";
+  let summary = "opaque value bundle passed between phases";
+}
+
 #endif // SILICON_MIR_TYPES_TD

--- a/lib/HIR/Ops.cpp
+++ b/lib/HIR/Ops.cpp
@@ -46,6 +46,344 @@ SuccessorOperands ConstCondBranchOp::getSuccessorOperands(unsigned index) {
 #include "silicon/HIR/Ops.cpp.inc"
 
 //===----------------------------------------------------------------------===//
+// SplitFuncOp
+//===----------------------------------------------------------------------===//
+
+// # Custom Parser for SplitFuncOp
+//
+// The assembly format is:
+//   hir.split_func @name(arg: phase, ...) -> (result: phase, ...) {
+//     <signature region>
+//   } [phase: @sym, ...]
+//
+// The parser extracts named+phased argument/result lists and a phase-to-symbol
+// map, storing them as properties on the op.
+
+ParseResult SplitFuncOp::parse(OpAsmParser &parser, OperationState &result) {
+  auto &props = result.getOrAddProperties<SplitFuncOp::Properties>();
+  auto *ctx = parser.getContext();
+  auto builder = OpBuilder(ctx);
+
+  // Parse optional visibility.
+  StringAttr visAttr;
+  if (parseSymbolVisibility(parser, visAttr))
+    return failure();
+  if (visAttr)
+    props.sym_visibility = visAttr;
+
+  // Parse symbol name.
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr))
+    return failure();
+  props.sym_name = nameAttr;
+
+  // Parse argument list: (name: phase, ...).
+  SmallVector<Attribute> argNames;
+  SmallVector<int32_t> argPhases;
+  if (parser.parseLParen())
+    return failure();
+  if (failed(parser.parseOptionalRParen())) {
+    do {
+      std::string name;
+      int32_t phase;
+      if (parser.parseKeywordOrString(&name) || parser.parseColon() ||
+          parser.parseInteger(phase))
+        return failure();
+      argNames.push_back(builder.getStringAttr(name));
+      argPhases.push_back(phase);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRParen())
+      return failure();
+  }
+  props.argNames = builder.getArrayAttr(argNames);
+  props.argPhases = builder.getDenseI32ArrayAttr(argPhases);
+
+  // Parse result list: -> (name: phase, ...).
+  SmallVector<Attribute> resultNames;
+  SmallVector<int32_t> resultPhases;
+  if (parser.parseArrow() || parser.parseLParen())
+    return failure();
+  if (failed(parser.parseOptionalRParen())) {
+    do {
+      std::string name;
+      int32_t phase;
+      if (parser.parseKeywordOrString(&name) || parser.parseColon() ||
+          parser.parseInteger(phase))
+        return failure();
+      resultNames.push_back(builder.getStringAttr(name));
+      resultPhases.push_back(phase);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRParen())
+      return failure();
+  }
+  props.resultNames = builder.getArrayAttr(resultNames);
+  props.resultPhases = builder.getDenseI32ArrayAttr(resultPhases);
+
+  // Parse signature region.
+  auto *region = result.addRegion();
+  if (parser.parseRegion(*region))
+    return failure();
+
+  // Parse phase map: [phase: @sym, ...].
+  SmallVector<int32_t> phaseNumbers;
+  SmallVector<Attribute> phaseFuncs;
+  if (parser.parseLSquare())
+    return failure();
+  if (failed(parser.parseOptionalRSquare())) {
+    do {
+      int32_t phase;
+      FlatSymbolRefAttr sym;
+      if (parser.parseInteger(phase) || parser.parseColon() ||
+          parser.parseAttribute(sym))
+        return failure();
+      phaseNumbers.push_back(phase);
+      phaseFuncs.push_back(sym);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRSquare())
+      return failure();
+  }
+  props.phaseNumbers = builder.getDenseI32ArrayAttr(phaseNumbers);
+  props.phaseFuncs = builder.getArrayAttr(phaseFuncs);
+
+  return success();
+}
+
+void SplitFuncOp::print(OpAsmPrinter &p) {
+  p << ' ';
+  printSymbolVisibility(p, *this, getSymVisibilityAttr());
+  p.printSymbolName(getSymName());
+
+  // Print argument list.
+  p << '(';
+  auto argNames = getArgNames();
+  auto argPhases = getArgPhases();
+  for (size_t i = 0, e = argNames.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << cast<StringAttr>(argNames[i]).getValue() << ": " << argPhases[i];
+  }
+  p << ')';
+
+  // Print result list.
+  p << " -> (";
+  auto resultNames = getResultNames();
+  auto resultPhases = getResultPhases();
+  for (size_t i = 0, e = resultNames.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << cast<StringAttr>(resultNames[i]).getValue() << ": " << resultPhases[i];
+  }
+  p << ") ";
+
+  // Print signature region.
+  p.printRegion(getSignature());
+
+  // Print phase map, one entry per line.
+  p << " [";
+  auto phaseNumbers = getPhaseNumbers();
+  auto phaseFuncs = getPhaseFuncs();
+  for (size_t i = 0, e = phaseNumbers.size(); i < e; ++i) {
+    if (i)
+      p << ',';
+    p.printNewline();
+    p << "  " << phaseNumbers[i] << ": ";
+    p.printAttribute(phaseFuncs[i]);
+  }
+  p.printNewline();
+  p << ']';
+}
+
+LogicalResult SplitFuncOp::verify() {
+  if (getArgPhases().size() != getArgNames().size())
+    return emitOpError() << "argPhases has " << getArgPhases().size()
+                         << " entries but function has " << getArgNames().size()
+                         << " arguments";
+
+  if (getResultPhases().size() != getResultNames().size())
+    return emitOpError() << "resultPhases has " << getResultPhases().size()
+                         << " entries but function has "
+                         << getResultNames().size() << " results";
+
+  if (getPhaseNumbers().size() != getPhaseFuncs().size())
+    return emitOpError() << "phaseNumbers has " << getPhaseNumbers().size()
+                         << " entries but phaseFuncs has "
+                         << getPhaseFuncs().size() << " entries";
+
+  // Verify the signature terminator's operand counts match.
+  auto sigOp = dyn_cast<SignatureOp>(getSignature().back().getTerminator());
+  if (!sigOp)
+    return success(); // verifyRegions will catch missing terminator
+
+  if (sigOp.getTypeOfArgs().size() != getArgNames().size())
+    return emitOpError() << "signature has " << sigOp.getTypeOfArgs().size()
+                         << " argument types but function has "
+                         << getArgNames().size() << " arguments";
+
+  if (sigOp.getTypeOfResults().size() != getResultNames().size())
+    return emitOpError() << "signature has " << sigOp.getTypeOfResults().size()
+                         << " result types but function has "
+                         << getResultNames().size() << " results";
+
+  return success();
+}
+
+LogicalResult SplitFuncOp::verifyRegions() {
+  if (!isa<SignatureOp>(getSignature().back().getTerminator()))
+    return emitOpError()
+           << "requires `hir.signature` terminator in the signature";
+  return success();
+}
+
+SignatureOp SplitFuncOp::getSignatureOp() {
+  return cast<SignatureOp>(getSignature().back().getTerminator());
+}
+
+//===----------------------------------------------------------------------===//
+// MultiphaseFuncOp
+//===----------------------------------------------------------------------===//
+
+// # Custom Parser for MultiphaseFuncOp
+//
+// The assembly format is:
+//   hir.multiphase_func @name(last arg, first arg, ...) -> (result, ...) [
+//     @sym, ...
+//   ]
+//
+// Each argument is preceded by `first` or `last` to indicate whether it
+// originates from the first or last sub-phase.
+
+ParseResult MultiphaseFuncOp::parse(OpAsmParser &parser,
+                                    OperationState &result) {
+  auto &props = result.getOrAddProperties<MultiphaseFuncOp::Properties>();
+  auto *ctx = parser.getContext();
+  auto builder = OpBuilder(ctx);
+
+  // Parse optional visibility.
+  StringAttr visAttr;
+  if (parseSymbolVisibility(parser, visAttr))
+    return failure();
+  if (visAttr)
+    props.sym_visibility = visAttr;
+
+  // Parse symbol name.
+  StringAttr nameAttr;
+  if (parser.parseSymbolName(nameAttr))
+    return failure();
+  props.sym_name = nameAttr;
+
+  // Parse argument list: ((first|last) name, ...).
+  SmallVector<Attribute> argNames;
+  SmallVector<bool> argIsFirst;
+  if (parser.parseLParen())
+    return failure();
+  if (failed(parser.parseOptionalRParen())) {
+    do {
+      StringRef keyword;
+      std::string name;
+      if (parser.parseKeyword(&keyword))
+        return failure();
+      if (keyword != "first" && keyword != "last")
+        return parser.emitError(parser.getCurrentLocation(),
+                                "expected 'first' or 'last'");
+      if (parser.parseKeywordOrString(&name))
+        return failure();
+      argNames.push_back(builder.getStringAttr(name));
+      argIsFirst.push_back(keyword == "first");
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRParen())
+      return failure();
+  }
+  props.argNames = builder.getArrayAttr(argNames);
+  props.argIsFirst = builder.getDenseBoolArrayAttr(argIsFirst);
+
+  // Parse result list: -> (name, ...).
+  SmallVector<Attribute> resultNames;
+  if (parser.parseArrow() || parser.parseLParen())
+    return failure();
+  if (failed(parser.parseOptionalRParen())) {
+    do {
+      std::string name;
+      if (parser.parseKeywordOrString(&name))
+        return failure();
+      resultNames.push_back(builder.getStringAttr(name));
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRParen())
+      return failure();
+  }
+  props.resultNames = builder.getArrayAttr(resultNames);
+
+  // Parse function list: [@sym, ...].
+  SmallVector<Attribute> phaseFuncs;
+  if (parser.parseLSquare())
+    return failure();
+  if (failed(parser.parseOptionalRSquare())) {
+    do {
+      FlatSymbolRefAttr sym;
+      if (parser.parseAttribute(sym))
+        return failure();
+      phaseFuncs.push_back(sym);
+    } while (succeeded(parser.parseOptionalComma()));
+    if (parser.parseRSquare())
+      return failure();
+  }
+  props.phaseFuncs = builder.getArrayAttr(phaseFuncs);
+
+  return success();
+}
+
+void MultiphaseFuncOp::print(OpAsmPrinter &p) {
+  p << ' ';
+  printSymbolVisibility(p, *this, getSymVisibilityAttr());
+  p.printSymbolName(getSymName());
+
+  // Print argument list.
+  p << '(';
+  auto argNames = getArgNames();
+  auto argIsFirst = getArgIsFirst();
+  for (size_t i = 0, e = argNames.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << (argIsFirst[i] ? "first" : "last") << ' '
+      << cast<StringAttr>(argNames[i]).getValue();
+  }
+  p << ')';
+
+  // Print result list.
+  p << " -> (";
+  auto resultNames = getResultNames();
+  for (size_t i = 0, e = resultNames.size(); i < e; ++i) {
+    if (i)
+      p << ", ";
+    p << cast<StringAttr>(resultNames[i]).getValue();
+  }
+  p << ") [";
+
+  // Print function list, one entry per line.
+  auto phaseFuncs = getPhaseFuncs();
+  for (size_t i = 0, e = phaseFuncs.size(); i < e; ++i) {
+    if (i)
+      p << ',';
+    p.printNewline();
+    p << "  ";
+    p.printAttribute(phaseFuncs[i]);
+  }
+  p.printNewline();
+  p << ']';
+}
+
+LogicalResult MultiphaseFuncOp::verify() {
+  if (getArgIsFirst().size() != getArgNames().size())
+    return emitOpError() << "argIsFirst has " << getArgIsFirst().size()
+                         << " entries but function has " << getArgNames().size()
+                         << " arguments";
+
+  if (getPhaseFuncs().empty())
+    return emitOpError() << "phaseFuncs must have at least one entry";
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // CallOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/HIR/Transforms/SplitPhases.cpp
+++ b/lib/HIR/Transforms/SplitPhases.cpp
@@ -528,6 +528,110 @@ void PhaseSplitter::run() {
     });
     mapping.clear();
   }
+
+  //===--------------------------------------------------------------------===//
+  // Emit Structural Ops
+  //
+  // Build a split_func recording the full phase-to-function mapping, and a
+  // multiphase_func wrapping compile-time sub-functions when there are 2+
+  // compile-time phases. The unified func is erased afterward.
+  //===--------------------------------------------------------------------===//
+
+  auto sfLoc = funcOp.getLoc();
+  auto sfName = funcOp.getSymNameAttr();
+  auto sfArgNames = funcOp.getArgNames();
+  SmallVector<int32_t> sfArgPhases(funcOp.getArgPhases());
+  SmallVector<int32_t> sfResultPhases(funcOp.getResultPhases());
+
+  // Create builder for structural ops, inserting after the last per-phase func.
+  auto *lastPhaseFunc = splits[maxPhase - minPhase].funcOp.getOperation();
+  OpBuilder sfBuilder(lastPhaseFunc->getBlock(),
+                      std::next(lastPhaseFunc->getIterator()));
+  auto *ctx = sfBuilder.getContext();
+
+  // Build phase-to-function mapping arrays.
+  SmallVector<int32_t> phaseNumbers;
+  SmallVector<Attribute> phaseFuncAttrs;
+  for (int16_t phase = minPhase; phase <= maxPhase; ++phase) {
+    phaseNumbers.push_back(phase);
+    phaseFuncAttrs.push_back(FlatSymbolRefAttr::get(
+        ctx, splits[phase - minPhase].funcOp.getSymName()));
+  }
+
+  // Generate synthetic result names.
+  SmallVector<Attribute> resultNameAttrs;
+  if (sfResultPhases.size() == 1) {
+    resultNameAttrs.push_back(sfBuilder.getStringAttr("result"));
+  } else {
+    for (unsigned i = 0; i < sfResultPhases.size(); ++i)
+      resultNameAttrs.push_back(sfBuilder.getStringAttr("result" + Twine(i)));
+  }
+
+  // Create the split_func.
+  auto splitFuncOp =
+      SplitFuncOp::create(sfBuilder, sfLoc, sfName,
+                          /*sym_visibility=*/StringAttr{}, sfArgNames,
+                          sfBuilder.getDenseI32ArrayAttr(sfArgPhases),
+                          sfBuilder.getArrayAttr(resultNameAttrs),
+                          sfBuilder.getDenseI32ArrayAttr(sfResultPhases),
+                          sfBuilder.getDenseI32ArrayAttr(phaseNumbers),
+                          sfBuilder.getArrayAttr(phaseFuncAttrs));
+
+  // Move the unified func's signature region into the split_func and replace
+  // the unified_signature terminator with a signature terminator.
+  splitFuncOp.getSignature().takeBody(funcOp.getSignature());
+  {
+    auto &sigBlock = splitFuncOp.getSignature().back();
+    auto unifiedSigOp = cast<UnifiedSignatureOp>(sigBlock.getTerminator());
+    OpBuilder sigBuilder(unifiedSigOp);
+    SignatureOp::create(sigBuilder, unifiedSigOp.getLoc(),
+                        unifiedSigOp.getTypeOfArgs(),
+                        unifiedSigOp.getTypeOfResults());
+    unifiedSigOp.erase();
+  }
+
+  // Emit a multiphase_func wrapping the compile-time sub-functions if there
+  // are 2+ compile-time phases (phases < 0).
+  if (minPhase <= -2) {
+    SmallVector<Attribute> constFuncAttrs;
+    for (int16_t phase = minPhase; phase < 0; ++phase)
+      constFuncAttrs.push_back(FlatSymbolRefAttr::get(
+          ctx, splits[phase - minPhase].funcOp.getSymName()));
+
+    // Only include compile-time args (phase < 0). An arg is "first" if it
+    // enters at the earliest compile-time phase, "last" otherwise.
+    SmallVector<Attribute> mpArgNames;
+    SmallVector<bool> mpArgIsFirst;
+    for (auto [name, phase] : llvm::zip(sfArgNames, sfArgPhases)) {
+      if (phase < 0) {
+        mpArgNames.push_back(name);
+        mpArgIsFirst.push_back(phase == minPhase);
+      }
+    }
+
+    // One result per value threaded from the last compile-time phase to phase
+    // 0.
+    auto lastConstRetOp = cast<ReturnOp>(
+        splits[-1 - minPhase].funcOp.getBody().back().getTerminator());
+    unsigned numCtx = lastConstRetOp.getNumOperands();
+    SmallVector<Attribute> mpResultNames;
+    if (numCtx == 1) {
+      mpResultNames.push_back(sfBuilder.getStringAttr("ctx"));
+    } else {
+      for (unsigned i = 0; i < numCtx; ++i)
+        mpResultNames.push_back(sfBuilder.getStringAttr("ctx" + Twine(i)));
+    }
+
+    MultiphaseFuncOp::create(
+        sfBuilder, sfLoc, sfBuilder.getStringAttr(sfName.getValue() + ".const"),
+        /*sym_visibility=*/StringAttr{}, sfBuilder.getArrayAttr(mpArgNames),
+        sfBuilder.getDenseBoolArrayAttr(mpArgIsFirst),
+        sfBuilder.getArrayAttr(mpResultNames),
+        sfBuilder.getArrayAttr(constFuncAttrs));
+  }
+
+  // Erase the unified func now that all data has been extracted.
+  symbolTable.erase(funcOp);
 }
 
 namespace {
@@ -604,6 +708,6 @@ void SplitPhasesPass::runOnOperation() {
     auto &[funcOp, analysis] = analyses[idx];
     PhaseSplitter splitter(analysis, symbolTable);
     splitter.run();
-    funcOp.erase();
+    // Unified func is erased inside run().
   }
 }

--- a/test/HIR/basic.mlir
+++ b/test/HIR/basic.mlir
@@ -68,3 +68,41 @@ hir.expr : !hir.any, !hir.any {
   %1 = hir.anyfunc_type
   hir.yield %0, %1 : !hir.any, !hir.any
 }
+
+// split_func with args, results, signature, and phase map
+hir.split_func @SplitExample(a: -3, b: -1) -> (c: 0) {
+^bb0(%a_arg: !hir.any, %b_arg: !hir.any):
+  %st0 = hir.int_type
+  hir.signature (%st0, %st0) -> (%st0)
+} [
+  -3: @SplitExample.0,
+  -1: @SplitExample.1,
+  0: @SplitExample.2
+]
+
+// split_func with no args/results
+hir.split_func @SplitNoArgs() -> () {
+  hir.signature () -> ()
+} [
+  0: @SplitNoArgs.0
+]
+
+// multiphase_func with first/last args
+hir.multiphase_func @Multi(last a, first b) -> (out) [
+  @Multi.0,
+  @Multi.1
+]
+
+// multiphase_func with no args
+hir.multiphase_func @MultiNoArgs() -> (out) [
+  @MultiNoArgs.0,
+  @MultiNoArgs.1,
+  @MultiNoArgs.2
+]
+
+// opaque ops
+hir.opaque_type
+%opaque_a = hir.int_type
+%opaque_b = hir.constant_int 42
+%packed = hir.opaque_pack (%opaque_a, %opaque_b)
+%unp_x, %unp_y = hir.opaque_unpack %packed : !hir.any, !hir.any

--- a/test/HIR/errors.mlir
+++ b/test/HIR/errors.mlir
@@ -179,3 +179,40 @@ hir.unified_func @foo [0] -> [0] attributes {argNames = ["a"]} {
 %int_type = hir.int_type
 // expected-error @below {{typeOfResults has 0 entries but call has 1 results}}
 %2 = hir.unified_call @foo(%arg) : (%int_type) -> () (!hir.any) -> !hir.any [0] -> [0]
+
+// -----
+
+// expected-error @below {{requires `hir.signature` terminator in the signature}}
+hir.split_func @bad_term() -> () {
+^bb0:
+  hir.const_br ^bb1
+^bb1:
+  hir.const_br ^bb1
+} [
+  0: @bad_term.0
+]
+
+// -----
+
+// expected-error @below {{signature has 1 argument types but function has 0 arguments}}
+hir.split_func @bad_sig_args() -> () {
+  %0 = hir.int_type
+  hir.signature (%0) -> ()
+} [
+  0: @bad_sig_args.0
+]
+
+// -----
+
+// expected-error @below {{signature has 1 result types but function has 0 results}}
+hir.split_func @bad_sig_results() -> () {
+  %0 = hir.int_type
+  hir.signature () -> (%0)
+} [
+  0: @bad_sig_results.0
+]
+
+// -----
+
+// expected-error @below {{phaseFuncs must have at least one entry}}
+hir.multiphase_func @empty_phases() -> (out) []

--- a/test/HIR/split-phases.mlir
+++ b/test/HIR/split-phases.mlir
@@ -10,6 +10,9 @@ func.func private @dummyB()
 // CHECK-NEXT: hir.return
 
 // CHECK-NOT: hir.unified_func
+// CHECK-LABEL: hir.split_func @SinglePhase() -> ()
+// CHECK:         hir.signature () -> ()
+// CHECK:       0: @SinglePhase.const0
 hir.unified_func @SinglePhase [] -> [] attributes {argNames = []} {
   hir.unified_signature () -> ()
 } {
@@ -31,6 +34,10 @@ hir.unified_func @SinglePhase [] -> [] attributes {argNames = []} {
 // CHECK-NEXT: hir.return
 
 // CHECK-NOT: hir.unified_func
+// CHECK-LABEL: hir.split_func @TwoUnrelatedPhases() -> ()
+// CHECK:         hir.signature () -> ()
+// CHECK:       -1: @TwoUnrelatedPhases.const1
+// CHECK:       0: @TwoUnrelatedPhases.const0
 hir.unified_func @TwoUnrelatedPhases [] -> [] attributes {argNames = []} {
   hir.unified_signature () -> ()
 } {
@@ -57,6 +64,10 @@ hir.unified_func @TwoUnrelatedPhases [] -> [] attributes {argNames = []} {
 // CHECK-NEXT: hir.return
 
 // CHECK-NOT: hir.unified_func
+// CHECK-LABEL: hir.split_func @ValueUseAcrossPhases() -> ()
+// CHECK:         hir.signature () -> ()
+// CHECK:       -1: @ValueUseAcrossPhases.const1
+// CHECK:       0: @ValueUseAcrossPhases.const0
 hir.unified_func @ValueUseAcrossPhases [] -> [] attributes {argNames = []} {
   hir.unified_signature () -> ()
 } {
@@ -83,6 +94,10 @@ hir.unified_func @ValueUseAcrossPhases [] -> [] attributes {argNames = []} {
 // CHECK-NEXT: hir.return [[R]]
 
 // CHECK-NOT: hir.unified_func
+// CHECK-LABEL: hir.split_func @ConstArg(a: -1, b: 0) -> (result: 0)
+// CHECK:         hir.signature
+// CHECK:       -1: @ConstArg.const1
+// CHECK:       0: @ConstArg.const0
 hir.unified_func @ConstArg [-1, 0] -> [0] attributes {argNames = ["a", "b"]} {
 ^bb0(%a: !hir.any, %b: !hir.any):
   %0 = hir.int_type
@@ -114,6 +129,14 @@ hir.unified_func @ConstArg [-1, 0] -> [0] attributes {argNames = ["a", "b"]} {
 // CHECK-NEXT: hir.return [[RES]]
 
 // CHECK-NOT: hir.unified_func
+// CHECK-LABEL: hir.split_func @ThreePhase(a: -2, b: -1, c: 0) -> (result: 0)
+// CHECK:         hir.signature
+// CHECK:       -2: @ThreePhase.const2
+// CHECK:       -1: @ThreePhase.const1
+// CHECK:       0: @ThreePhase.const0
+// CHECK-LABEL: hir.multiphase_func @ThreePhase.const(first a, last b) -> (ctx)
+// CHECK:       @ThreePhase.const2
+// CHECK:       @ThreePhase.const1
 hir.unified_func @ThreePhase [-2, -1, 0] -> [0] attributes {argNames = ["a", "b", "c"]} {
 ^bb0(%a: !hir.any, %b: !hir.any, %c: !hir.any):
   %0 = hir.int_type
@@ -143,6 +166,14 @@ hir.unified_func @ThreePhase [-2, -1, 0] -> [0] attributes {argNames = ["a", "b"
 // CHECK: hir.return
 
 // CHECK-NOT: hir.unified_func
+// CHECK-LABEL: hir.split_func @ThreePhaseCaller(z: 0) -> (result: 0)
+// CHECK:         hir.signature
+// CHECK:       -2: @ThreePhaseCaller.const2
+// CHECK:       -1: @ThreePhaseCaller.const1
+// CHECK:       0: @ThreePhaseCaller.const0
+// CHECK-LABEL: hir.multiphase_func @ThreePhaseCaller.const() -> (ctx)
+// CHECK:       @ThreePhaseCaller.const2
+// CHECK:       @ThreePhaseCaller.const1
 hir.unified_func @ThreePhaseCaller [0] -> [0] attributes {argNames = ["z"]} {
 ^bb0(%z: !hir.any):
   %0 = hir.int_type

--- a/test/MIR/basic.mlir
+++ b/test/MIR/basic.mlir
@@ -39,3 +39,10 @@ func.func @Return2(%arg0: !mir.type, %arg1: !mir.int) {
 mir.call @foo() : () -> ()
 mir.call @foo(%int_type) : (!mir.type) -> (!mir.type)
 mir.call @foo(%int_type, %c42_int) : (!mir.type, !mir.int) -> (!mir.type, !mir.int)
+
+// Opaque type
+unrealized_conversion_cast to !mir.opaque
+
+// Opaque pack/unpack
+%opaque_ctx = mir.opaque_pack (%c42_int, %int_type) : (!mir.int, !mir.type)
+%opaque_a, %opaque_b = mir.opaque_unpack %opaque_ctx : !mir.int, !mir.type


### PR DESCRIPTION
After creating per-phase hir.func ops, the SplitPhases pass now also emits hir.split_func and hir.multiphase_func structural ops.

split_func records the full phase-to-function mapping plus a cloned signature region (with hir.signature replacing hir.unified_signature). It is always emitted, one per unified_func.

multiphase_func wraps the compile-time sub-functions (phases < 0) when there are 2+ such phases. Args are classified as "first" (entering at the earliest phase) or "last" (entering at a later phase). Results correspond to values threaded from the last compile-time phase to phase 0.

Downstream passes continue to work via naming convention for now; the structural ops are purely additive.