### PR TITLE
Add opaque_pack/unpack for cross-phase value threading

### DIFF
--- a/include/silicon/MIR/Attributes.td
+++ b/include/silicon/MIR/Attributes.td
@@ -79,4 +79,17 @@ def SpecializedFuncAttr : MIRAttrDef<"SpecializedFunc", [
   }];
 }
 
+def OpaqueAttr : MIRAttrDef<"Opaque", [
+  DeclareAttrInterfaceMethods<TypedAttrInterface>
+]> {
+  let mnemonic = "opaque";
+  let summary = "opaque bundle of values passed between phases";
+  let parameters = (ins
+    OptionalArrayRefParameter<"mlir::Attribute">:$elements
+  );
+  let assemblyFormat = [{
+    `<` `[` (`]`) : ($elements^ `]`)? `>`
+  }];
+}
+
 #endif // SILICON_MIR_ATTRIBUTES_TD

--- a/include/silicon/MIR/Ops.td
+++ b/include/silicon/MIR/Ops.td
@@ -92,18 +92,18 @@ def CallOp : MIROp<"call"> {
 def MIROpaquePackOp : MIROp<"opaque_pack", [Pure]> {
   let summary = "Pack multiple values into a single opaque bundle";
   let arguments = (ins Variadic<AnyType>:$operands);
-  let results = (outs OpaqueType:$result);
+  let results = (outs AnyType:$result);
   let assemblyFormat = [{
-    `(` $operands `)` `:` `(` type($operands) `)` attr-dict
+    `(` $operands `)` `:` `(` type($operands) `)` `->` type($result) attr-dict
   }];
 }
 
 def MIROpaqueUnpackOp : MIROp<"opaque_unpack", [Pure]> {
   let summary = "Unpack an opaque bundle into individual values";
-  let arguments = (ins OpaqueType:$input);
+  let arguments = (ins AnyType:$input);
   let results = (outs Variadic<AnyType>:$results);
   let assemblyFormat = [{
-    $input `:` type($results) attr-dict
+    $input `:` type($input) `->` type($results) attr-dict
   }];
 }
 

--- a/lib/Conversion/HIRToMIR.cpp
+++ b/lib/Conversion/HIRToMIR.cpp
@@ -219,6 +219,23 @@ static LogicalResult convert(hir::CallOp op, hir::CallOp::Adaptor adaptor,
   return success();
 }
 
+static LogicalResult convert(hir::OpaquePackOp op,
+                             hir::OpaquePackOp::Adaptor adaptor,
+                             ConversionPatternRewriter &rewriter) {
+  auto opaqueType = mir::OpaqueType::get(op.getContext());
+  rewriter.replaceOpWithNewOp<mir::MIROpaquePackOp>(op, opaqueType,
+                                                    adaptor.getOperands());
+  return success();
+}
+
+static LogicalResult convert(hir::OpaqueUnpackOp op,
+                             hir::OpaqueUnpackOp::Adaptor adaptor,
+                             ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOpWithNewOp<mir::MIROpaqueUnpackOp>(op, op.getResultTypes(),
+                                                      adaptor.getInput());
+  return success();
+}
+
 static LogicalResult convert(UnrealizedConversionCastOp op,
                              UnrealizedConversionCastOp::Adaptor adaptor,
                              ConversionPatternRewriter &rewriter) {
@@ -283,6 +300,8 @@ void HIRToMIRPass::runOnOperation() {
   patterns.add<hir::SpecializeFuncOp>(convert);
   patterns.add<hir::ReturnOp>(convert);
   patterns.add<hir::CallOp>(convert);
+  patterns.add<hir::OpaquePackOp>(convert);
+  patterns.add<hir::OpaqueUnpackOp>(convert);
   patterns.add<UnrealizedConversionCastOp>(convert);
 
   // Setup the legal ops.

--- a/lib/HIR/Transforms/SplitPhases.cpp
+++ b/lib/HIR/Transforms/SplitPhases.cpp
@@ -448,6 +448,18 @@ void PhaseSplitter::run() {
     }
   }
 
+  // Record the number of "own" block args and return values for each phase
+  // function before cross-phase threading adds context values. These counts
+  // are used afterward to bundle context values into opaque packs.
+  SmallVector<unsigned> numOwnArgs(maxPhase - minPhase + 1);
+  SmallVector<unsigned> numOwnReturns(maxPhase - minPhase + 1);
+  for (int16_t phase = minPhase; phase <= maxPhase; ++phase) {
+    numOwnArgs[phase - minPhase] =
+        splits[phase - minPhase].funcOp.getBody().front().getNumArguments();
+    numOwnReturns[phase - minPhase] =
+        splits[phase - minPhase].returnValues.size();
+  }
+
   // Add return operations to all phase functions and plumb values from earlier
   // phases to later phases. We iterate in reverse execution order (most-runtime
   // first, most-const last) so that thread-through adds values to later splits
@@ -527,6 +539,61 @@ void PhaseSplitter::run() {
       }
     });
     mapping.clear();
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bundle Context Values into Opaque Packs
+  //
+  // For each phase boundary, bundle the context values (added during
+  // cross-phase threading) into a single `hir.opaque_pack` at the source
+  // phase's return, and unpack them with `hir.opaque_unpack` at the target
+  // phase's entry. This ensures each phase boundary passes a single opaque
+  // bundle instead of individual values.
+  //===--------------------------------------------------------------------===//
+
+  auto anyType = AnyType::get(builder.getContext());
+  for (int16_t phase = minPhase + 1; phase <= maxPhase; ++phase) {
+    auto &split = splits[phase - minPhase];
+    auto &block = split.funcOp.getBody().front();
+    unsigned ownArgs = numOwnArgs[phase - minPhase];
+    unsigned totalArgs = block.getNumArguments();
+    unsigned contextArgs = totalArgs - ownArgs;
+    if (contextArgs == 0)
+      continue;
+
+    // In this phase: replace trailing context block args with a single opaque
+    // arg followed by an opaque_unpack.
+    auto opaqueArg = block.addArgument(anyType, funcOp.getLoc());
+    OpBuilder unpackBuilder(&block, block.begin());
+    auto unpackOp = OpaqueUnpackOp::create(
+        unpackBuilder, funcOp.getLoc(), SmallVector<Type>(contextArgs, anyType),
+        opaqueArg);
+    for (unsigned i = 0; i < contextArgs; ++i)
+      block.getArgument(ownArgs + i).replaceAllUsesWith(unpackOp.getResult(i));
+    block.eraseArguments(ownArgs, contextArgs);
+
+    // In the previous phase: replace trailing context return values with a
+    // single opaque_pack.
+    auto &prevSplit = splits[phase - 1 - minPhase];
+    auto prevReturnOp =
+        cast<ReturnOp>(prevSplit.funcOp.getBody().back().getTerminator());
+    unsigned prevOwnReturns = numOwnReturns[phase - 1 - minPhase];
+    unsigned prevTotalReturns = prevReturnOp.getNumOperands();
+    unsigned contextReturns = prevTotalReturns - prevOwnReturns;
+    if (contextReturns == 0)
+      continue;
+
+    OpBuilder packBuilder(prevReturnOp);
+    SmallVector<Value> contextValues(
+        prevReturnOp.getOperands().drop_front(prevOwnReturns));
+    auto packOp =
+        OpaquePackOp::create(packBuilder, funcOp.getLoc(), contextValues);
+
+    SmallVector<Value> newReturnValues(
+        prevReturnOp.getOperands().take_front(prevOwnReturns));
+    newReturnValues.push_back(packOp);
+    ReturnOp::create(packBuilder, funcOp.getLoc(), newReturnValues);
+    prevReturnOp.erase();
   }
 
   //===--------------------------------------------------------------------===//

--- a/lib/MIR/Attributes.cpp
+++ b/lib/MIR/Attributes.cpp
@@ -51,3 +51,9 @@ Type UnitAttr::getType() const { return UnitType::get(getContext()); }
 Type SpecializedFuncAttr::getType() const {
   return SpecializedFuncType::get(getContext());
 }
+
+//===----------------------------------------------------------------------===//
+// OpaqueAttr
+//===----------------------------------------------------------------------===//
+
+Type OpaqueAttr::getType() const { return OpaqueType::get(getContext()); }

--- a/lib/Transforms/Interpret.cpp
+++ b/lib/Transforms/Interpret.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "silicon/HIR/Ops.h"
+#include "silicon/MIR/Attributes.h"
 #include "silicon/MIR/Ops.h"
 #include "silicon/Support/MLIR.h"
 #include "silicon/Transforms/Passes.h"
@@ -114,6 +115,13 @@ LogicalResult Interpreter::run() {
       if (!attr)
         return op->emitError() << "interpretation failed";
       frame.values[specializeFuncOp] = attr;
+    } else if (auto packOp = dyn_cast<mir::MIROpaquePackOp>(op)) {
+      frame.values[packOp] = mir::OpaqueAttr::get(op->getContext(), operands);
+    } else if (auto unpackOp = dyn_cast<mir::MIROpaqueUnpackOp>(op)) {
+      auto opaqueAttr = cast<mir::OpaqueAttr>(operands[0]);
+      for (auto [result, elem] :
+           llvm::zip(unpackOp.getResults(), opaqueAttr.getElements()))
+        frame.values[result] = elem;
     } else {
       return op->emitError() << "operation not supported by interpreter";
     }

--- a/test/HIR/split-phases.mlir
+++ b/test/HIR/split-phases.mlir
@@ -86,10 +86,12 @@ hir.unified_func @ValueUseAcrossPhases [] -> [] attributes {argNames = []} {
 
 // CHECK-LABEL: hir.func private @ConstArg.const1
 // CHECK-NEXT: ^bb0([[A:%.+]]: !hir.any):
-// CHECK-NEXT: hir.return [[A]]
+// CHECK-NEXT: [[PACK:%.+]] = hir.opaque_pack([[A]])
+// CHECK-NEXT: hir.return [[PACK]]
 
 // CHECK-LABEL: hir.func private @ConstArg.const0
-// CHECK-NEXT: ^bb0([[B:%.+]]: !hir.any, [[A:%.+]]: !hir.any):
+// CHECK-NEXT: ^bb0([[B:%.+]]: !hir.any, [[OPAQUE:%.+]]: !hir.any):
+// CHECK-NEXT: [[A:%.+]] = hir.opaque_unpack [[OPAQUE]]
 // CHECK-NEXT: [[R:%.+]] = hir.binary [[A]], [[B]]
 // CHECK-NEXT: hir.return [[R]]
 
@@ -116,15 +118,19 @@ hir.unified_func @ConstArg [-1, 0] -> [0] attributes {argNames = ["a", "b"]} {
 
 // CHECK-LABEL: hir.func private @ThreePhase.const2
 // CHECK-NEXT: ^bb0([[A:%.+]]: !hir.any):
-// CHECK-NEXT: hir.return [[A]]
+// CHECK-NEXT: [[PACK:%.+]] = hir.opaque_pack([[A]])
+// CHECK-NEXT: hir.return [[PACK]]
 
 // CHECK-LABEL: hir.func private @ThreePhase.const1
-// CHECK-NEXT: ^bb0([[B:%.+]]: !hir.any, [[A:%.+]]: !hir.any):
+// CHECK-NEXT: ^bb0([[B:%.+]]: !hir.any, [[OPAQUE:%.+]]: !hir.any):
+// CHECK-NEXT: [[A:%.+]] = hir.opaque_unpack [[OPAQUE]]
 // CHECK-NEXT: [[TMP:%.+]] = hir.binary [[A]], [[B]]
-// CHECK-NEXT: hir.return [[TMP]]
+// CHECK-NEXT: [[PACK:%.+]] = hir.opaque_pack([[TMP]])
+// CHECK-NEXT: hir.return [[PACK]]
 
 // CHECK-LABEL: hir.func private @ThreePhase.const0
-// CHECK-NEXT: ^bb0([[C:%.+]]: !hir.any, [[AB:%.+]]: !hir.any):
+// CHECK-NEXT: ^bb0([[C:%.+]]: !hir.any, [[OPAQUE:%.+]]: !hir.any):
+// CHECK-NEXT: [[AB:%.+]] = hir.opaque_unpack [[OPAQUE]]
 // CHECK-NEXT: [[RES:%.+]] = hir.binary [[AB]], [[C]]
 // CHECK-NEXT: hir.return [[RES]]
 
@@ -155,13 +161,17 @@ hir.unified_func @ThreePhase [-2, -1, 0] -> [0] attributes {argNames = ["a", "b"
 
 // CHECK-LABEL: hir.func private @ThreePhaseCaller.const2
 // CHECK: hir.call @ThreePhase.const2(
+// CHECK: hir.opaque_pack(
 // CHECK: hir.return
 
 // CHECK-LABEL: hir.func private @ThreePhaseCaller.const1
+// CHECK: hir.opaque_unpack
 // CHECK: hir.call @ThreePhase.const1(
+// CHECK: hir.opaque_pack(
 // CHECK: hir.return
 
 // CHECK-LABEL: hir.func private @ThreePhaseCaller.const0
+// CHECK: hir.opaque_unpack
 // CHECK: hir.call @ThreePhase.const0(
 // CHECK: hir.return
 

--- a/test/MIR/basic.mlir
+++ b/test/MIR/basic.mlir
@@ -40,9 +40,10 @@ mir.call @foo() : () -> ()
 mir.call @foo(%int_type) : (!mir.type) -> (!mir.type)
 mir.call @foo(%int_type, %c42_int) : (!mir.type, !mir.int) -> (!mir.type, !mir.int)
 
-// Opaque type
+// Opaque type and attribute
 unrealized_conversion_cast to !mir.opaque
+unrealized_conversion_cast to index {attr = #mir.opaque<[#mir.int<42>, #mir.type<!mir.int>]>}
 
 // Opaque pack/unpack
-%opaque_ctx = mir.opaque_pack (%c42_int, %int_type) : (!mir.int, !mir.type)
-%opaque_a, %opaque_b = mir.opaque_unpack %opaque_ctx : !mir.int, !mir.type
+%opaque_ctx = mir.opaque_pack (%c42_int, %int_type) : (!mir.int, !mir.type) -> !mir.opaque
+%opaque_a, %opaque_b = mir.opaque_unpack %opaque_ctx : !mir.opaque -> !mir.int, !mir.type

--- a/test/Transforms/interpret.mlir
+++ b/test/Transforms/interpret.mlir
@@ -55,3 +55,34 @@ hir.multiphase_func @Chain.const() -> (ctx) [
   @Chain.const2,
   @Chain.const1
 ]
+
+//===----------------------------------------------------------------------===//
+// Opaque-bundled chaining: same as above, but using mir.opaque_pack/unpack to
+// pass the context value as an opaque bundle between phases.
+
+// CHECK-LABEL: hir.func private @OpaqueChain.const2
+// CHECK-NEXT: [[PACKED:%.+]] = mir.constant #mir.opaque
+// CHECK-NEXT: mir.return [[PACKED]]
+hir.func private @OpaqueChain.const2 {
+  %0 = mir.constant #mir.int<42> : !mir.int
+  %1 = mir.opaque_pack(%0) : (!mir.int) -> !mir.opaque
+  mir.return %1 : !mir.opaque
+}
+
+// CHECK-LABEL: hir.func private @OpaqueChain.const1
+// CHECK-NEXT: [[C52:%.+]] = mir.constant #mir.int<52>
+// CHECK-NEXT: mir.return [[C52]]
+hir.func private @OpaqueChain.const1 {
+^bb0(%packed: !mir.opaque):
+  %0 = mir.opaque_unpack %packed : !mir.opaque -> !mir.int
+  %1 = mir.constant #mir.int<10> : !mir.int
+  %2 = mir.binary %0, %1 : !mir.int
+  mir.return %2 : !mir.int
+}
+
+hir.split_func @OpaqueChain() -> () {
+  hir.signature () -> ()
+} [
+  -2: @OpaqueChain.const2,
+  -1: @OpaqueChain.const1
+]


### PR DESCRIPTION
Bundle cross-phase context values into opaque packs at phase boundaries in SplitPhases: each source phase returns a single `hir.opaque_pack` of its context values, and the target phase receives a single opaque arg that it unpacks with `hir.opaque_unpack`.

Add `#mir.opaque` attribute to hold packed values at the MIR level, with HIRToMIR lowering for the opaque ops and interpreter support for evaluating them. Relax MIR opaque op type constraints from `!mir.opaque` to `AnyType` so they work with `!hir.any` block args before lowering.